### PR TITLE
correct rendering utf-8 IFrame

### DIFF
--- a/branca/element.py
+++ b/branca/element.py
@@ -309,7 +309,7 @@ class Figure(Element):
 
         """
         html = self.render(**kwargs)
-        html = "data:text/html;base64," + base64.b64encode(html.encode('utf8')).decode('utf8')  # noqa
+        html = "data:text/html;charset=utf-8;base64," + base64.b64encode(html.encode('utf8')).decode('utf8')  # noqa
 
         if self.height is None:
             iframe = (


### PR DESCRIPTION
The iframe didn't render properly utf-8 text, because the charset is missing
without charset
![bad_folium_rendering](https://cloud.githubusercontent.com/assets/2539833/16979947/1c1693a4-4e64-11e6-9b37-80e2b0b6b9d9.PNG)
with charset
![good_folium_rendering](https://cloud.githubusercontent.com/assets/2539833/16979954/22251c02-4e64-11e6-90c6-1fd315869d00.PNG)
