### PR TITLE
Remove embedded IFrame's border

### DIFF
--- a/branca/element.py
+++ b/branca/element.py
@@ -551,14 +551,15 @@ class IFrame(Element):
             iframe = (
             '<div style="width:{width};">'
             '<div style="position:relative;width:100%;height:0;padding-bottom:{ratio};">'  # noqa
-            '<iframe src="{html}" style="position:absolute;width:100%;height:100%;left:0;top:0;">'  # noqa
+            '<iframe src="{html}" style="position:absolute;width:100%;height:100%;left:0;top:0;'  # noqa
+            'border:none !important;">'
             '</iframe>'
             '</div></div>').format
             iframe = iframe(html=html,
                             width=self.width,
                             ratio=self.ratio)
         else:
-            iframe = ('<iframe src="{html}" width="{width}" '
+            iframe = ('<iframe src="{html}" width="{width}" style="border:none !important;" '
                       'height="{height}"></iframe>').format
             iframe = iframe(html=html, width=self.width, height=self.height)
         return iframe


### PR DESCRIPTION
Fixes the original issue for #16, and I believe that the changes made in #16 to the `Figure` class should stay as it is, as itself also creates an IFrame
