### PR TITLE
correct rendering utf-8 IFrame (again)

### DIFF
--- a/branca/element.py
+++ b/branca/element.py
@@ -545,7 +545,7 @@ class IFrame(Element):
     def render(self, **kwargs):
         """Renders the HTML representation of the element."""
         html = super(IFrame, self).render(**kwargs)
-        html = "data:text/html;base64," + base64.b64encode(html.encode('utf8')).decode('utf8')  # noqa
+        html = "data:text/html;charset=utf-8;base64," + base64.b64encode(html.encode('utf8')).decode('utf8')  # noqa
 
         if self.height is None:
             iframe = (

--- a/tests/test_iframe.py
+++ b/tests/test_iframe.py
@@ -16,6 +16,7 @@ def test_create_iframe():
     iframe = elem.IFrame(html="<p>test content<p>", width=60, height=45)
     iframe.render()
 
+
 def test_rendering_utf8_iframe():
     iframe = elem.IFrame(html=u"<p>Cerrahpaşa Tıp Fakültesi</p>")
     driver = webdriver.PhantomJS()

--- a/tests/test_iframe.py
+++ b/tests/test_iframe.py
@@ -5,18 +5,20 @@ Folium Element Module class IFrame
 """
 import branca.element as elem
 from selenium import webdriver
-import base64
+
+
 def test_create_empty_iframe():
-	iframe = elem.IFrame()
-	iframe.render()
+    iframe = elem.IFrame()
+    iframe.render()
+
 
 def test_create_iframe():
-	iframe = elem.IFrame(html="<p>test content<p>",width=60,height=45)
-	iframe.render()
+    iframe = elem.IFrame(html="<p>test content<p>", width=60, height=45)
+    iframe.render()
 
 def test_rendering_utf8_iframe():
-	iframe = elem.IFrame(html=u"<p>Cerrahpaşa Tıp Fakültesi</p>")
-	driver = webdriver.PhantomJS()
-	driver.get("data:text/html," + iframe.render())
-	driver.switch_to.frame(0);
-	assert u"Cerrahpaşa Tıp Fakültesi" in driver.page_source
+    iframe = elem.IFrame(html=u"<p>Cerrahpaşa Tıp Fakültesi</p>")
+    driver = webdriver.PhantomJS()
+    driver.get("data:text/html," + iframe.render())
+    driver.switch_to.frame(0)
+    assert u"Cerrahpaşa Tıp Fakültesi" in driver.page_source

--- a/tests/test_iframe.py
+++ b/tests/test_iframe.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+""""
+Folium Element Module class IFrame
+----------------------
+"""
+import branca.element as elem
+from selenium import webdriver
+import base64
+def test_create_empty_iframe():
+	iframe = elem.IFrame()
+	iframe.render()
+
+def test_create_iframe():
+	iframe = elem.IFrame(html="<p>test content<p>",width=60,height=45)
+	iframe.render()
+
+def test_rendering_utf8_iframe():
+	iframe = elem.IFrame(html="<p>Cerrahpaşa Tıp Fakültesi</p>")
+	driver = webdriver.PhantomJS()
+	driver.get("data:text/html," + iframe.render())
+	driver.switch_to.frame(0);
+	assert "Cerrahpaşa Tıp Fakültesi" in driver.page_source

--- a/tests/test_iframe.py
+++ b/tests/test_iframe.py
@@ -15,8 +15,8 @@ def test_create_iframe():
 	iframe.render()
 
 def test_rendering_utf8_iframe():
-	iframe = elem.IFrame(html="<p>Cerrahpaşa Tıp Fakültesi</p>")
+	iframe = elem.IFrame(html=u"<p>Cerrahpaşa Tıp Fakültesi</p>")
 	driver = webdriver.PhantomJS()
 	driver.get("data:text/html," + iframe.render())
 	driver.switch_to.frame(0);
-	assert "Cerrahpaşa Tıp Fakültesi" in driver.page_source
+	assert u"Cerrahpaşa Tıp Fakültesi" in driver.page_source


### PR DESCRIPTION
Hi,

I was too hasty last time and only update one of the two line that need the "charset:utf-8"
So here the full version + a dedicated test for IFrame element including rendering.
But for this test phantomJs is required and it's not installable using pip (selenium also but I simply add it in requirement-dev.txt).
And I am not  sure if this is worth breaking automatic installation for this.
