### PR TITLE
Reversing color support for colorbrewer schemes

### DIFF
--- a/branca/utilities.py
+++ b/branca/utilities.py
@@ -108,6 +108,12 @@ def color_brewer(color_code, n=6):
 
     """
     maximum_n = 253
+    if color_code[-2:] == '_r':
+        core_color_code = color_code[:-2]
+        color_reverse = True
+    else:
+        core_color_code = color_code
+        color_reverse = False
 
     scheme_info = {'BuGn': 'Sequential',
                    'BuPu': 'Sequential',
@@ -207,18 +213,24 @@ def color_brewer(color_code, n=6):
 
     # Only if n is greater than six do we interpolate values.
     if n > 6:
-        if color_code not in schemes:
+        if core_color_code not in schemes:
             color_scheme = None
         else:
             # Check to make sure that it is not a qualitative scheme.
-            if scheme_info[color_code] == 'Qualitative':
+            if scheme_info[core_color_code] == 'Qualitative':
                 raise ValueError("Expanded color support is not available"
                                  " for Qualitative schemes, restrict"
                                  " number of colors to 6")
             else:
-                color_scheme = linear_gradient(schemes.get(color_code), n)
+                if not color_reverse:
+                    color_scheme = linear_gradient(schemes.get(core_color_code), n)
+                else:
+                    color_scheme = linear_gradient(schemes.get(core_color_code)[::-1], n)
     else:
-        color_scheme = schemes.get(color_code, None)
+        if not color_reverse:
+            color_scheme = schemes.get(core_color_code, None)
+        else:
+            color_scheme = schemes.get(core_color_code, None)[::-1]
     return color_scheme
 
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,0 +1,16 @@
+import branca.utilities as ut
+
+
+def test_color_brewer_base():
+    scheme = ut.color_brewer('YlGnBu', 9)
+    assert scheme == [
+        '#ffffcc', '#d5eeba', '#a3dbb7',
+        '#6fc7bd', '#41b6c4', '#269ac1',
+        '#1f77b4', '#1c519f', '#0c2c84'
+    ]
+
+
+def test_color_brewer_reverse():
+    scheme = ut.color_brewer('YlGnBu')
+    scheme_r = ut.color_brewer('YlGnBu_r')
+    assert scheme[::-1] == scheme_r


### PR DESCRIPTION
The way folium seems to create my choropleths is with the color gradients going the "wrong" direction.  This change simply allows for a "_r" at the end of the color code supplied to color_brewer() to allow for a reversal of the scheme.