### PR TITLE
make children an OrderedDict when adding child with index

### DIFF
--- a/branca/element.py
+++ b/branca/element.py
@@ -100,7 +100,7 @@ class Element(object):
             items = [item for item in self._children.items()
                      if item[0] != name]
             items.insert(int(index), (name, child))
-            self._children = items
+            self._children = OrderedDict(items)
         child._parent = self
         return self
 


### PR DESCRIPTION
When you try to add a child with an index number, `add_child` reassigns the object attribute `_children` as a list when it should be an OrderedDict. Fixed that