### PR TITLE
Add hooks to aid with HTML/JS minification

### DIFF
--- a/branca/element.py
+++ b/branca/element.py
@@ -275,13 +275,13 @@ class Figure(Element):
         '<!DOCTYPE html>\n'
         '<head>'
         '{% if this.title %}<title>{{this.title}}</title>{% endif %}'
-        '{{format_header(this.header.render(**kwargs))}}'
+        '{{this.format_header(this.header.render(**kwargs))}}'
         '</head>\n'
         '<body>'
-        '{{format_html(this.html.render(**kwargs))}}'
+        '{{this.format_html(this.html.render(**kwargs))}}'
         '</body>\n'
         '<script>'
-        '{{format_script(this.script.render(**kwargs))}}'
+        '{{this.format_script(this.script.render(**kwargs))}}'
         '</script>\n'
     )
 
@@ -333,8 +333,7 @@ class Figure(Element):
         """Renders the HTML representation of the element."""
         for name, child in self._children.items():
             child.render(**kwargs)
-        return self._template.render(this=self, kwargs=kwargs, format_header=self.format_header,
-                                     format_html=self.format_html, format_script=self.format_script)
+        return self._template.render(this=self, kwargs=kwargs)
 
     def _repr_html_(self, **kwargs):
         """Displays the Figure in a Jupyter notebook.

--- a/examples/Elements.ipynb
+++ b/examples/Elements.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import sys\n",
@@ -31,9 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "e = Element(\"This is fancy text\")"
@@ -49,16 +45,14 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Element a1d0f648f7444f96b526931944247fd6\n",
-      "element_a1d0f648f7444f96b526931944247fd6\n"
+      "Element c1eb25dfe0a44dd9a05c587f79b8001e\n",
+      "element_c1eb25dfe0a44dd9a05c587f79b8001e\n"
      ]
     }
    ],
@@ -77,9 +71,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -106,14 +98,12 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'Hello World, my name is `element_6f17661abddb45c7bf2aa794cadd327d`.'"
+       "'Hello World, my name is `element_4cd3f750a3114f908cbc780234355234`.'"
       ]
      },
      "execution_count": 5,
@@ -136,9 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "child = Element('This is the child.')\n",
@@ -158,9 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -184,9 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -216,14 +200,12 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "OrderedDict([('child_1', <branca.element.Element at 0x7f758f2db6a0>)])"
+       "OrderedDict([('child_1', <branca.element.Element at 0x7fcd5938a9b0>)])"
       ]
      },
      "execution_count": 9,
@@ -247,9 +229,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -292,22 +272,17 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "<!DOCTYPE html>\n",
-      "<head>    \n",
-      "    <meta http-equiv=\"content-type\" content=\"text/html; charset=UTF-8\" />\n",
-      "</head>\n",
-      "<body>    \n",
-      "</body>\n",
-      "<script>    \n",
-      "</script>\n"
+      "<head>\n",
+      "    <meta http-equiv=\"content-type\" content=\"text/html; charset=UTF-8\" /></head>\n",
+      "<body></body>\n",
+      "<script></script>\n"
      ]
     }
    ],
@@ -326,24 +301,19 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "<!DOCTYPE html>\n",
-      "<head>    \n",
+      "<head>\n",
       "    <meta http-equiv=\"content-type\" content=\"text/html; charset=UTF-8\" />\n",
-      "    <style>body {background-color: #00ffff}</style>\n",
-      "</head>\n",
-      "<body>    \n",
-      "    <h1>Hello world</h1>\n",
-      "</body>\n",
-      "<script>    \n",
-      "</script>\n"
+      "    <style>body {background-color: #00ffff}</style></head>\n",
+      "<body>\n",
+      "    <h1>Hello world</h1></body>\n",
+      "<script></script>\n"
      ]
     }
    ],
@@ -363,24 +333,19 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "<!DOCTYPE html>\n",
-      "<head>    \n",
+      "<head>\n",
       "    <meta http-equiv=\"content-type\" content=\"text/html; charset=UTF-8\" />\n",
-      "    <style>body {background-color: #00ffff}</style>\n",
-      "</head>\n",
-      "<body>    \n",
-      "    <h1>Hello world</h1>\n",
-      "</body>\n",
-      "<script>    \n",
-      "</script>\n"
+      "    <style>body {background-color: #00ffff}</style></head>\n",
+      "<body>\n",
+      "    <h1>Hello world</h1></body>\n",
+      "<script></script>\n"
      ]
     }
    ],
@@ -399,17 +364,15 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<div style=\"width:100%;\"><div style=\"position:relative;width:100%;height:0;padding-bottom:60%;\"><iframe src=\"data:text/html;base64,PCFET0NUWVBFIGh0bWw+CjxoZWFkPiAgICAKICAgIDxtZXRhIGh0dHAtZXF1aXY9ImNvbnRlbnQtdHlwZSIgY29udGVudD0idGV4dC9odG1sOyBjaGFyc2V0PVVURi04IiAvPgogICAgPHN0eWxlPmJvZHkge2JhY2tncm91bmQtY29sb3I6ICMwMGZmZmZ9PC9zdHlsZT4KPC9oZWFkPgo8Ym9keT4gICAgCiAgICA8aDE+SGVsbG8gd29ybGQ8L2gxPgo8L2JvZHk+CjxzY3JpcHQ+ICAgIAo8L3NjcmlwdD4=\" style=\"position:absolute;width:100%;height:100%;left:0;top:0;\"></iframe></div></div>"
+       "<div style=\"width:100%;\"><div style=\"position:relative;width:100%;height:0;padding-bottom:60%;\"><iframe src=\"data:text/html;charset=utf-8;base64,PCFET0NUWVBFIGh0bWw+CjxoZWFkPgogICAgPG1ldGEgaHR0cC1lcXVpdj0iY29udGVudC10eXBlIiBjb250ZW50PSJ0ZXh0L2h0bWw7IGNoYXJzZXQ9VVRGLTgiIC8+CiAgICA8c3R5bGU+Ym9keSB7YmFja2dyb3VuZC1jb2xvcjogIzAwZmZmZn08L3N0eWxlPjwvaGVhZD4KPGJvZHk+CiAgICA8aDE+SGVsbG8gd29ybGQ8L2gxPjwvYm9keT4KPHNjcmlwdD48L3NjcmlwdD4=\" style=\"position:absolute;width:100%;height:100%;left:0;top:0;border:none !important;\" allowfullscreen webkitallowfullscreen mozallowfullscreen></iframe></div></div>"
       ],
       "text/plain": [
-       "<branca.element.Figure at 0x7f758f2db2b0>"
+       "<branca.element.Figure at 0x7fcd583232b0>"
       ]
      },
      "execution_count": 14,
@@ -431,17 +394,15 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<iframe src=\"data:text/html;base64,PCFET0NUWVBFIGh0bWw+CjxoZWFkPiAgICAKICAgIDxtZXRhIGh0dHAtZXF1aXY9ImNvbnRlbnQtdHlwZSIgY29udGVudD0idGV4dC9odG1sOyBjaGFyc2V0PVVURi04IiAvPgogICAgPHN0eWxlPmJvZHkge2JhY2tncm91bmQtY29sb3I6ICMwMGZmZmZ9PC9zdHlsZT4KPC9oZWFkPgo8Ym9keT4gICAgCiAgICA8aDE+SGVsbG8gd29ybGQ8L2gxPgo8L2JvZHk+CjxzY3JpcHQ+ICAgIAo8L3NjcmlwdD4=\" width=\"300\" height=\"200\"></iframe>"
+       "<iframe src=\"data:text/html;charset=utf-8;base64,PCFET0NUWVBFIGh0bWw+CjxoZWFkPgogICAgPG1ldGEgaHR0cC1lcXVpdj0iY29udGVudC10eXBlIiBjb250ZW50PSJ0ZXh0L2h0bWw7IGNoYXJzZXQ9VVRGLTgiIC8+CiAgICA8c3R5bGU+Ym9keSB7YmFja2dyb3VuZC1jb2xvcjogIzAwZmZmZn08L3N0eWxlPjwvaGVhZD4KPGJvZHk+CiAgICA8aDE+SGVsbG8gd29ybGQ8L2gxPjwvYm9keT4KPHNjcmlwdD48L3NjcmlwdD4=\" width=\"300\" height=\"200\"style=\"border:none !important;\" \"allowfullscreen\" \"webkitallowfullscreen\" \"mozallowfullscreen\"></iframe>"
       ],
       "text/plain": [
-       "<branca.element.Figure at 0x7f758f2db2b0>"
+       "<branca.element.Figure at 0x7fcd583232b0>"
       ]
      },
      "execution_count": 15,
@@ -465,17 +426,15 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<iframe src=\"data:text/html;base64,PCFET0NUWVBFIGh0bWw+CjxoZWFkPiAgICAKICAgIDxtZXRhIGh0dHAtZXF1aXY9ImNvbnRlbnQtdHlwZSIgY29udGVudD0idGV4dC9odG1sOyBjaGFyc2V0PVVURi04IiAvPgo8L2hlYWQ+Cjxib2R5PiAgICAKPC9ib2R5Pgo8c2NyaXB0PiAgICAKPC9zY3JpcHQ+\" width=\"300px\" height=\"300px\"></iframe>"
+       "<iframe src=\"data:text/html;charset=utf-8;base64,PCFET0NUWVBFIGh0bWw+CjxoZWFkPgogICAgPG1ldGEgaHR0cC1lcXVpdj0iY29udGVudC10eXBlIiBjb250ZW50PSJ0ZXh0L2h0bWw7IGNoYXJzZXQ9VVRGLTgiIC8+PC9oZWFkPgo8Ym9keT48L2JvZHk+CjxzY3JpcHQ+PC9zY3JpcHQ+\" width=\"300px\" height=\"300px\"style=\"border:none !important;\" \"allowfullscreen\" \"webkitallowfullscreen\" \"mozallowfullscreen\"></iframe>"
       ],
       "text/plain": [
-       "<branca.element.Figure at 0x7f758f052f98>"
+       "<branca.element.Figure at 0x7fcd5832c5f8>"
       ]
      },
      "execution_count": 16,
@@ -504,25 +463,20 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "<!DOCTYPE html>\n",
-      "<head>    \n",
+      "<head>\n",
       "    <meta http-equiv=\"content-type\" content=\"text/html; charset=UTF-8\" />\n",
-      "    This is header of macro_element_ea36a310ab8a4212a8c7ca754a4140fc\n",
-      "</head>\n",
-      "<body>    \n",
-      "    This is html of macro_element_ea36a310ab8a4212a8c7ca754a4140fc\n",
-      "</body>\n",
-      "<script>    \n",
-      "    This is script of macro_element_ea36a310ab8a4212a8c7ca754a4140fc\n",
-      "</script>\n"
+      "    This is header of macro_element_3ce9fe4a9a3b40ddaa7a3ca2d415824e</head>\n",
+      "<body>\n",
+      "    This is html of macro_element_3ce9fe4a9a3b40ddaa7a3ca2d415824e</body>\n",
+      "<script>\n",
+      "    This is script of macro_element_3ce9fe4a9a3b40ddaa7a3ca2d415824e</script>\n"
      ]
     }
    ],
@@ -562,9 +516,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -585,14 +537,12 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'<link rel=\"stylesheet\" href=\"https://example.com/style.css\" />'"
+       "'<link rel=\"stylesheet\" href=\"https://example.com/style.css\"/>'"
       ]
      },
      "execution_count": 19,
@@ -621,18 +571,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 20,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'<div id=\"html_cec7064e3ecc492ca40ac8c6f63ce839\" style=\"width: 100.0%; height: 100.0%;\">Hello world</div>'"
+       "'<div id=\"html_ca7fc6279cb445d8bdb866aecef52d76\" style=\"width: 100.0%; height: 100.0%;\">Hello world</div>'"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -651,18 +599,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 21,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'<div id=\"html_18a1f0cf2e61444d8a396ad5cb77f864\" style=\"width: 100.0%; height: 100.0%;\">&lt;b&gt;Hello world&lt;/b&gt;</div>'"
+       "'<div id=\"html_1d3d9328228f4ba9b86713dd68b0119a\" style=\"width: 100.0%; height: 100.0%;\">&lt;b&gt;Hello world&lt;/b&gt;</div>'"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -680,18 +626,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 22,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'<div id=\"html_9cf0c436b7f0462ea59479bc9175e72a\" style=\"width: 100.0%; height: 100.0%;\"><b>Hello world</b></div>'"
+       "'<div id=\"html_381e16130f524baa95202a047c401ca0\" style=\"width: 100.0%; height: 100.0%;\"><b>Hello world</b></div>'"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -716,18 +660,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 23,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'<div style=\"width:100%;\"><div style=\"position:relative;width:100%;height:0;padding-bottom:60%;\"><iframe src=\"data:text/html;base64,CiAgICBIZWxsbyBXb3JsZA==\" style=\"position:absolute;width:100%;height:100%;left:0;top:0;\"></iframe></div></div>'"
+       "'<div style=\"width:100%;\"><div style=\"position:relative;width:100%;height:0;padding-bottom:60%;\"><iframe src=\"data:text/html;charset=utf-8;base64,CiAgICBIZWxsbyBXb3JsZA==\" style=\"position:absolute;width:100%;height:100%;left:0;top:0;border:none !important;\"></iframe></div></div>'"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -746,21 +688,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 24,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<iframe src=\"data:text/html;base64,PCFET0NUWVBFIGh0bWw+CjxoZWFkPiAgICAKICAgIDxtZXRhIGh0dHAtZXF1aXY9ImNvbnRlbnQtdHlwZSIgY29udGVudD0idGV4dC9odG1sOyBjaGFyc2V0PVVURi04IiAvPgo8L2hlYWQ+Cjxib2R5PiAgICAKICAgIEJlZm9yZSB0aGUgZnJhbWUKICAgIDxpZnJhbWUgc3JjPSJkYXRhOnRleHQvaHRtbDtiYXNlNjQsQ2lBZ0lDQkpiaUIwYUdVZ1puSmhiV1U9IiB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDBweCI+PC9pZnJhbWU+CiAgICBBZnRlciB0aGUgZnJhbWUKPC9ib2R5Pgo8c2NyaXB0PiAgICAKPC9zY3JpcHQ+\" width=\"100%\" height=\"180\"></iframe>"
+       "<iframe src=\"data:text/html;charset=utf-8;base64,PCFET0NUWVBFIGh0bWw+CjxoZWFkPgogICAgPG1ldGEgaHR0cC1lcXVpdj0iY29udGVudC10eXBlIiBjb250ZW50PSJ0ZXh0L2h0bWw7IGNoYXJzZXQ9VVRGLTgiIC8+PC9oZWFkPgo8Ym9keT4KICAgIEJlZm9yZSB0aGUgZnJhbWUKICAgIDxpZnJhbWUgc3JjPSJkYXRhOnRleHQvaHRtbDtjaGFyc2V0PXV0Zi04O2Jhc2U2NCxDaUFnSUNCSmJpQjBhR1VnWm5KaGJXVT0iIHdpZHRoPSIxMDAlIiBzdHlsZT0iYm9yZGVyOm5vbmUgIWltcG9ydGFudDsiIGhlaWdodD0iMTAwcHgiPjwvaWZyYW1lPgogICAgQWZ0ZXIgdGhlIGZyYW1lPC9ib2R5Pgo8c2NyaXB0Pjwvc2NyaXB0Pg==\" width=\"100%\" height=\"180\"style=\"border:none !important;\" \"allowfullscreen\" \"webkitallowfullscreen\" \"mozallowfullscreen\"></iframe>"
       ],
       "text/plain": [
-       "<branca.element.Figure at 0x7f758f07a8d0>"
+       "<branca.element.Figure at 0x7fcd58337978>"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -794,31 +734,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 25,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "<!DOCTYPE html>\n",
-      "<head>    \n",
+      "<head>\n",
       "    <meta http-equiv=\"content-type\" content=\"text/html; charset=UTF-8\" />\n",
-      "    <style> #div_e72aae6984604f7093a46452870bbebd {\n",
+      "    <style> #div_6d2fcdda5c09430bad47134c0aaa980d {\n",
       "        position : relative;\n",
       "        width : 100.0%;\n",
       "        height: 100.0%;\n",
       "        left: 0.0%;\n",
       "        top: 0.0%;\n",
-      "    </style>\n",
-      "</head>\n",
-      "<body>    \n",
-      "    <div id=\"div_e72aae6984604f7093a46452870bbebd\">Hello world</div>\n",
-      "</body>\n",
-      "<script>    \n",
-      "</script>\n"
+      "    </style></head>\n",
+      "<body>\n",
+      "    <div id=\"div_6d2fcdda5c09430bad47134c0aaa980d\">Hello world</div></body>\n",
+      "<script></script>\n"
      ]
     }
    ],
@@ -826,6 +761,66 @@
     "div = Div()\n",
     "div.html.add_child(Element('Hello world'))\n",
     "print(Figure().add_child(div).render())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Minification"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can apply any function to the head, body or script parts of the `Figure` by setting it as `format_header`, `format_html` or `format_script`. This is useful if you want to minify the resulting HTML/JavaScript."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<!DOCTYPE html>\n",
+      "<head>\n",
+      "    <meta http-equiv=\"content-type\" content=\"text/html; charset=UTF-8\" /></head>\n",
+      "<body>\n",
+      "        <h1>Hello world</h1>    </body>\n",
+      "<script></script>\n"
+     ]
+    }
+   ],
+   "source": [
+    "f = Figure()\n",
+    "f.html.add_child(Element(\"    <h1>Hello world</h1>    \"))\n",
+    "print(f.render())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<!DOCTYPE html>\n",
+      "<head><meta http-equiv=\"content-type\" content=\"text/html; charset=UTF-8\" /></head>\n",
+      "<body><h1>Hello world</h1></body>\n",
+      "<script></script>\n"
+     ]
+    }
+   ],
+   "source": [
+    "f = Figure(format_header=str.strip, format_html=str.strip)\n",
+    "f.html.add_child(Element(\"    <h1>Hello world</h1>    \"))\n",
+    "print(f.render())"
    ]
   }
  ],


### PR DESCRIPTION
Addresses python-visualization/folium#975

My understanding is that since `Figure` is the top-level `Element`, we can apply transformations such as minification there, to the entire thing at once. This only adds a hook with no additional dependencies for the library: it's up to the caller to decide what they want to do with the resulting JavaScript.

In particular, this enables setting a particular JS minifier in `folium.Map`.

For completeness, same mechanism is made available for `<head>` and `<body>` parts of the template.
