### PR TITLE
Assert color type in color_brewer

### DIFF
--- a/branca/utilities.py
+++ b/branca/utilities.py
@@ -119,6 +119,8 @@ def color_brewer(color_code, n=6):
         raise ValueError("The minimum number of colors in a"
                          " ColorBrewer sequential color series is 3")
 
+    assert isinstance(color_code, str), \
+        'color should be a string, not a {}.'.format(type(color_code))
     if color_code[-2:] == '_r':
         base_code = color_code[:-2]
         core_color_code = base_code + '_' + str(n).zfill(2)

--- a/branca/utilities.py
+++ b/branca/utilities.py
@@ -119,8 +119,9 @@ def color_brewer(color_code, n=6):
         raise ValueError("The minimum number of colors in a"
                          " ColorBrewer sequential color series is 3")
 
-    assert isinstance(color_code, str), \
-        'color should be a string, not a {}.'.format(type(color_code))
+    if not isinstance(color_code, str):
+        raise ValueError('color should be a string, not a {}.'
+                         .format(type(color_code)))
     if color_code[-2:] == '_r':
         base_code = color_code[:-2]
         core_color_code = base_code + '_' + str(n).zfill(2)


### PR DESCRIPTION
Close https://github.com/python-visualization/folium/issues/1051

Assert that the color value a user provides is a string before doing other operations. This solves the problem where slicing and comparing something that's not a string can lead to ambiguous error messages.