### PR TITLE
fix caption being propagated in scale funtions

### DIFF
--- a/branca/colormap.py
+++ b/branca/colormap.py
@@ -330,6 +330,7 @@ class LinearColormap(ColorMap):
             index=[vmin + (vmax-vmin)*(x-self.vmin)*1./(self.vmax-self.vmin) for x in self.index],  # noqa
             vmin=vmin,
             vmax=vmax,
+            caption=self.caption,
             )
 
 
@@ -417,6 +418,7 @@ class StepColormap(ColorMap):
             index=[vmin + (vmax-vmin)*(x-self.vmin)*1./(self.vmax-self.vmin) for x in self.index],  # noqa
             vmin=vmin,
             vmax=vmax,
+            caption=self.caption,
             )
 
 


### PR DESCRIPTION
Hi everyone, small fix: If you use the `caption` keyword in `LinearColormap` or `StepColormap` and apply afterwards `scale`, the caption is reset to empty string. Fix propagates the caption. 
For the problem see also the screenshot, the second caption does not appear. I would like to share the ipython notebook, but unfortunately I cannot attach it here, feel free to contact me directly.

![Screenshot_2019-07-12 Colormaps](https://user-images.githubusercontent.com/42178034/61156683-45b55d00-a4f4-11e9-858b-a32d04858a7e.jpg)
