### PR TITLE
Colormap alpha

### DIFF
--- a/branca/colormap.py
+++ b/branca/colormap.py
@@ -126,15 +126,21 @@ class ColorMap(MacroElement):
 
     def rgb_hex_str(self, x):
         """Provides the color corresponding to value `x` in the
-        form of a string of hewadecimal values "#RRGGBB".
+        form of a string of hexadecimal values "#RRGGBB".
         """
         return '#%02x%02x%02x' % self.rgb_bytes_tuple(x)
 
+    def rgba_hex_str(self, x):
+        """Provides the color corresponding to value `x` in the
+        form of a string of hexadecimal values "#RRGGBBAA".
+        """
+        return '#%02x%02x%02x%02x' % self.rgba_bytes_tuple(x)
+
     def __call__(self, x):
         """Provides the color corresponding to value `x` in the
-        form of a string of hewadecimal values "#RRGGBB".
+        form of a string of hexadecimal values "#RRGGBBAA".
         """
-        return self.rgb_hex_str(x)
+        return self.rgba_hex_str(x)
 
     def _repr_html_(self):
         return (
@@ -143,7 +149,7 @@ class ColorMap(MacroElement):
                 [('<line x1="{i}" y1="0" x2="{i}" '
                   'y2="20" style="stroke:{color};stroke-width:3;" />').format(
                       i=i*1,
-                      color=self.rgb_hex_str(self.vmin +
+                      color=self.rgba_hex_str(self.vmin +
                                              (self.vmax-self.vmin)*i/499.))
                  for i in range(500)]) +
             '<text x="0" y="35">{}</text>'.format(self.vmin) +

--- a/branca/colormap.py
+++ b/branca/colormap.py
@@ -149,8 +149,10 @@ class ColorMap(MacroElement):
                 [('<line x1="{i}" y1="0" x2="{i}" '
                   'y2="20" style="stroke:{color};stroke-width:3;" />').format(
                       i=i*1,
-                      color=self.rgba_hex_str(self.vmin +
-                                             (self.vmax-self.vmin)*i/499.))
+                      color=self.rgba_hex_str(
+                          self.vmin +
+                          (self.vmax-self.vmin)*i/499.)
+                  )
                  for i in range(500)]) +
             '<text x="0" y="35">{}</text>'.format(self.vmin) +
             '<text x="500" y="35" style="text-anchor:end;">{}</text>'.format(


### PR DESCRIPTION
Addressing issue #63:
Colormaps will now respect the alpha channels supplied by the user.
Note that this might break some plots, but personally I think that using the alpha values is the expected behavior.
