### PR TITLE
Store html content in a data-html attribute.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ env:
   - MOZ_HEADLESS=1
 
 addons:
+  apt:
+    packages:
+      - libgtk-3-0
   firefox: latest
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
     packages:
       # Without libgtk (as of 2019-11-6), firefox cannot run properly
       - libgtk-3-0
+    update: false
   firefox: latest
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
 addons:
   apt:
     packages:
+      # Without libgtk (as of 2019-11-6), firefox cannot run properly
       - libgtk-3-0
   firefox: latest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ env:
 
 addons:
   apt:
+    update: false
     packages:
       # Without libgtk (as of 2019-11-6), firefox cannot run properly
       - libgtk-3-0
-    update: false
   firefox: latest
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env:
 
 addons:
   apt:
-    update: false
     packages:
       # Without libgtk (as of 2019-11-6), firefox cannot run properly
       - libgtk-3-0

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ matrix:
     env: PY=3.7
 
 before_install:
-  # Install gtk dependency for firefox
-  - sudo apt -y install libgtk-3-0
   # Install miniconda and create TEST env.
   - |
     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
@@ -44,7 +42,7 @@ before_install:
     conda info --all
   # Install firefox headless driver.
   - |
-    wget https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz -O geckodriver.tar.gz
+    wget https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-linux64.tar.gz -O geckodriver.tar.gz
     mkdir geckodriver
     tar -xzf geckodriver.tar.gz -C geckodriver
     export PATH=$PATH:$PWD/geckodriver

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_install:
     conda info --all
   # Install firefox headless driver.
   - |
-    wget https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-linux64.tar.gz -O geckodriver.tar.gz
+    wget https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz -O geckodriver.tar.gz
     mkdir geckodriver
     tar -xzf geckodriver.tar.gz -C geckodriver
     export PATH=$PATH:$PWD/geckodriver

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ matrix:
     env: PY=3.7
 
 before_install:
+  # Install gtk dependency for firefox
+  - sudo apt -y install libgtk-3-0
   # Install miniconda and create TEST env.
   - |
     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh

--- a/branca/element.py
+++ b/branca/element.py
@@ -322,30 +322,36 @@ class Figure(Element):
         return self._template.render(this=self, kwargs=kwargs)
 
     def _repr_html_(self, **kwargs):
-        """Displays the Figure in a Jupyter notebook.
-
-        """
-        html = self.render(**kwargs)
-        html = "data:text/html;charset=utf-8;base64," + base64.b64encode(html.encode('utf8')).decode('utf8')  # noqa
+        """Displays the Figure in a Jupyter notebook."""
+        # Base64-encoded HTML is stored in a data-html attribute, which is used to populate
+        # the iframe. This approach does not encounter the 2MB limit in Chrome for storing
+        # the HTML in the src attribute with a data URI. The alternative of using a srcdoc
+        # attribute is not supported in Microsoft Internet Explorer and Edge.
+        html = base64.b64encode(self.render(**kwargs).encode('utf8')).decode('utf8')
+        onload = (
+            'this.contentDocument.open();'
+            'this.contentDocument.write(atob(this.getAttribute(\'data-html\')));'
+            'this.contentDocument.close();'
+        )
 
         if self.height is None:
             iframe = (
             '<div style="width:{width};">'
             '<div style="position:relative;width:100%;height:0;padding-bottom:{ratio};">'  # noqa
-            '<iframe src="{html}" style="position:absolute;width:100%;height:100%;left:0;top:0;'  # noqa
+            '<iframe src="about:blank" style="position:absolute;width:100%;height:100%;left:0;top:0;'  # noqa
             'border:none !important;" '
+            'data-html={html} onload="{onload}" '
             'allowfullscreen webkitallowfullscreen mozallowfullscreen>'
             '</iframe>'
             '</div></div>').format
-            iframe = iframe(html=html,
-                            width=self.width,
-                            ratio=self.ratio)
+            iframe = iframe(html=html, onload=onload, width=self.width, ratio=self.ratio)
         else:
-            iframe = ('<iframe src="{html}" width="{width}" height="{height}"'
+            iframe = ('<iframe src="about:blank" width="{width}" height="{height}"'
                       'style="border:none !important;" '
+                      'data-html={html} onload="{onload}" '
                       '"allowfullscreen" "webkitallowfullscreen" "mozallowfullscreen">'  # noqa
                       '</iframe>').format
-            iframe = iframe(html=html, width=self.width, height=self.height)
+            iframe = iframe(html=html, onload=onload, width=self.width, height=self.height)
         return iframe
 
     def add_subplot(self, x, y, n, margin=0.05):


### PR DESCRIPTION
This is a workaround for https://github.com/python-visualization/folium/issues/812.

The prior approach of using a data URI for the `src` attribute can encounter a 2MB limit in Chrome, which is problematic for displaying folium maps with a lot of data (examples given in the aforementioned issue).

The approach proposed here is to use a `data-html` attribute containing the underlying html that will be used to populate the iframe. This requires javascript. It's not particularly elegant in my opinion, but it was the best I could think of given the trade offs.

An alternative approach, which I utilized to monkey patch folium/branca temporarily for a dashboard I created, is to use a `srcdoc` attribute in addition to the data URI in the `src`. `srcdoc` is not supported in IE/Edge, but utilizing the data URI in `src` combined with `srcdoc` works (the `srcdoc` is utilized by browsers that recognize it). However, this approach stores redundant data in `src` and `srcdoc`, and also requires special handling to escape the HTML stored under `srcdoc` (e.g., for quotes and ampersands).