### PR TITLE
Remove py2k

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ install:
 
 script:
   - if [[ $TRAVIS_JOB_NAME == python-* ]]; then
-      cp -r tests/ /tmp ;
+      cp -r tests/ examples/ /tmp ;
       pushd /tmp && pytest -n 2 -rxs --cov=branca -vv tests && popd ;
     fi
 

--- a/branca/__init__.py
+++ b/branca/__init__.py
@@ -1,35 +1,10 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-
-import sys
-
 import branca.colormap as colormap
 import branca.element as element
 
 from ._version import get_versions
+
 __version__ = get_versions()['version']
 del get_versions
-
-if sys.version_info < (3, 0):
-    raise ImportError(
-        """You are running branca {} on Python 2
-
-    branca 0.4 and above are no longer compatible with Python 2, but somehow
-    you got this version anyway. Make sure you have pip >= 9.0 to avoid this
-    kind of issue, as well as setuptools >= 24.2:
-
-     $ pip install pip setuptools --upgrade
-
-    Your choices:
-
-    - Upgrade to Python 3.
-
-    - Install an older version of branca:
-
-     $ pip install 'branca<0.4.0'
-
-    """.format(__version__))  # noqa
 
 
 __all__ = [

--- a/branca/colormap.py
+++ b/branca/colormap.py
@@ -6,19 +6,14 @@ Utility module for dealing with colormaps.
 
 """
 
-from __future__ import absolute_import
-
 import json
 import math
 import os
 
-from branca.element import ENV, Figure, JavascriptLink, MacroElement
-from branca.utilities import legend_scaler
-
 from jinja2 import Template
 
-from six import binary_type, text_type
-
+from branca.element import ENV, Figure, JavascriptLink, MacroElement
+from branca.utilities import legend_scaler
 
 rootpath = os.path.abspath(os.path.dirname(__file__))
 
@@ -42,9 +37,9 @@ def _parse_hex(color_code):
 def _parse_color(x):
     if isinstance(x, (tuple, list)):
         color_tuple = tuple(x)[:4]
-    elif isinstance(x, (text_type, binary_type)) and _is_hex(x):
+    elif isinstance(x, (str, bytes)) and _is_hex(x):
         color_tuple = _parse_hex(x)
-    elif isinstance(x, (text_type, binary_type)):
+    elif isinstance(x, (str, bytes)):
         cname = _cnames.get(x.lower(), None)
         if cname is None:
             raise ValueError('Unknown color {!r}.'.format(cname))

--- a/branca/element.py
+++ b/branca/element.py
@@ -10,15 +10,12 @@ import base64
 import json
 import warnings
 from collections import OrderedDict
+from urllib.request import urlopen
 from uuid import uuid4
 
 from jinja2 import Environment, PackageLoader, Template
 
-from six import binary_type, text_type
-from six.moves.urllib.request import urlopen
-
 from .utilities import _camelify, _parse_size, none_max, none_min
-
 
 ENV = Environment(loader=PackageLoader('branca', 'templates'))
 
@@ -160,7 +157,7 @@ class Element(object):
         close_file : bool, default True
             Whether the file has to be closed after write.
         """
-        if isinstance(outfile, text_type) or isinstance(outfile, binary_type):
+        if isinstance(outfile, str) or isinstance(outfile, bytes):
             fid = open(outfile, 'wb')
         else:
             fid = outfile
@@ -559,7 +556,7 @@ class IFrame(Element):
             self.width = str(60*figsize[0])+'px'
             self.height = str(60*figsize[1])+'px'
 
-        if isinstance(html, text_type) or isinstance(html, binary_type):
+        if isinstance(html, str) or isinstance(html, bytes):
             self.add_child(Element(html))
         elif html is not None:
             self.add_child(html)

--- a/branca/utilities.py
+++ b/branca/utilities.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Utilities
 -------
@@ -6,8 +5,6 @@ Utilities
 Utility module for Folium helper functions.
 
 """
-
-from __future__ import absolute_import, division, print_function
 
 import base64
 import json
@@ -17,9 +14,6 @@ import struct
 import zlib
 
 from jinja2 import Environment, PackageLoader
-
-
-from six import binary_type, text_type
 
 try:
     import pandas as pd
@@ -244,8 +238,8 @@ def image_to_url(image, colormap=None, origin='upper'):
             fileformat = 'png'
         url = 'data:image/{};base64,{}'.format(
             fileformat, base64.b64encode(image.read()).decode('utf-8'))
-    elif (not (isinstance(image, text_type) or
-               isinstance(image, binary_type))) and hasattr(image, '__iter__'):
+    elif (not (isinstance(image, str) or
+               isinstance(image, bytes))) and hasattr(image, '__iter__'):
         # We got an array-like object.
         png = write_png(image, origin=origin, colormap=colormap)
         url = 'data:image/png;base64,' + base64.b64encode(png).decode('utf-8')

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,6 +24,7 @@ copyright = '2018, Filipe Fernandes'
 author = 'Filipe Fernandes'
 
 from branca._version import get_versions
+
 version = release = get_versions()['version']
 del get_versions
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ flake8-comprehensions
 flake8-mutable
 flake8-print
 isort
+jupyter
 nbsphinx
 pylint
 pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,11 @@
+black
 check-manifest
 flake8
 flake8-builtins
 flake8-comprehensions
-flake8-import-order
 flake8-mutable
 flake8-print
+isort
 nbsphinx
 pylint
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 jinja2
-six

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 from setuptools import setup
 
@@ -22,24 +21,6 @@ def walk_subpkg(name):
             data_files.append(os.path.join(sub_dir, f))
     return data_files
 
-
-if sys.version_info < (3, 5):
-    error = """
-    branca 0.4+ supports Python 3.5 and above.
-    When using Python 2.7, please install branca 0.3.*.
-
-    See branca `README.rst` file for more information:
-
-    https://github.com/python-visualization/branca/blob/master/README.rst
-
-    Python {py} detected.
-
-    Try upgrading pip and retry.
-    """.format(
-        py=".".join([str(v) for v in sys.version_info[:3]])
-    )
-    print(error, file=sys.stderr)  # noqa
-    sys.exit(1)
 
 pkg_data = {
     "": [
@@ -74,9 +55,11 @@ setup(
     url="https://github.com/python-visualization/branca",
     keywords="data visualization",
     classifiers=[
+        "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "License :: OSI Approved :: MIT License",
         "Development Status :: 5 - Production/Stable",
     ],

--- a/tests/test_iframe.py
+++ b/tests/test_iframe.py
@@ -5,12 +5,11 @@ Folium Element Module class IFrame
 ----------------------
 """
 
-import branca.element as elem
-
 import pytest
-
 from selenium.webdriver import Firefox
 from selenium.webdriver.firefox.options import Options
+
+import branca.element as elem
 
 
 def test_create_empty_iframe():

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Branca Notebooks Tests
 ----------------------
@@ -7,38 +6,39 @@ Here we try to execute all notebooks that are in `branca/examples`.
 """
 
 import os
-import sys
+
+import nbconvert
 
 import branca.utilities
 
-if sys.version_info[:2] == (3, 4):
-    import nbconvert
+rootpath = os.path.abspath(os.path.dirname(__file__))
 
-    rootpath = os.path.abspath(os.path.dirname(__file__))
 
-    class NotebookTester(object):
-        def __init__(self, filename):
-            self.filename = filename
+class NotebookTester(object):
+    def __init__(self, filename):
+        self.filename = filename
 
-        def __call__(self, exporter=None, filename=None):
-            raw_nb = nbconvert.exporters.Exporter().from_filename(self.filename)
-            raw_nb[0].metadata.setdefault('kernelspec', {})['name'] = 'python'
-            exec_nb = nbconvert.preprocessors.ExecutePreprocessor().preprocess(*raw_nb)
+    def __call__(self, exporter=None, filename=None):
+        raw_nb = nbconvert.exporters.Exporter().from_filename(self.filename)
+        raw_nb[0].metadata.setdefault('kernelspec', {})['name'] = 'python'
+        exec_nb = nbconvert.preprocessors.ExecutePreprocessor().preprocess(*raw_nb)
 
-            if exporter is not None:
-                out_nb = nbconvert.exporters.MarkdownExporter().from_notebook_node(*exec_nb)
-                if filename is None:
-                    assert self.filename.endswith('.ipynb')
-                    filename = self.filename[:-6] + exporter.file_extension
-                open(filename, 'w').write(out_nb[0].encode('utf-8'))
+        if exporter is not None:
+            out_nb = nbconvert.exporters.MarkdownExporter().from_notebook_node(*exec_nb)
+            if filename is None:
+                assert self.filename.endswith('.ipynb')
+                filename = self.filename[:-6] + exporter.file_extension
+            open(filename, 'w').write(out_nb[0].encode('utf-8'))
 
-    class TestNotebooks(object):
-        _filepath = rootpath.rstrip('/')+'/../examples/'
-        _nblist = [x for x in os.listdir(_filepath) if x.endswith('.ipynb')]
 
-    for fn in TestNotebooks._nblist:
-        setattr(
-            TestNotebooks,
-            'test_'+branca.utilities._camelify(fn[:-6]),
-            NotebookTester(TestNotebooks._filepath+fn).__call__
-        )
+class TestNotebooks(object):
+    _filepath = rootpath.rstrip('/')+'/../examples/'
+    _nblist = [x for x in os.listdir(_filepath) if x.endswith('.ipynb')]
+
+
+for fn in TestNotebooks._nblist:
+    setattr(
+        TestNotebooks,
+        'test_'+branca.utilities._camelify(fn[:-6]),
+        NotebookTester(TestNotebooks._filepath+fn).__call__
+    )


### PR DESCRIPTION
Wait for https://github.com/python-visualization/branca/pull/68 to be merged first.

- Drop Python 2 specific code
- Run `isort` and drop flake8-import-order

My plan is to send another PR dropping more `flake8` stuff and implement `isort`+`black` via pre-commit hooks and maybe a GH action.