### PR TITLE
Add message to trust notebook

### DIFF
--- a/branca/element.py
+++ b/branca/element.py
@@ -335,7 +335,7 @@ class Figure(Element):
             iframe = (
             '<div style="width:{width};">'
             '<div style="position:relative;width:100%;height:0;padding-bottom:{ratio};">'  # noqa
-            '<span style="color:#565656">Make this Notebook Trusted to load map: File -> Trust Notebook</span>'
+            '<span style="color:#565656">Make this Notebook Trusted to load map: File -> Trust Notebook</span>'  # noqa
             '<iframe src="about:blank" style="position:absolute;width:100%;height:100%;left:0;top:0;'  # noqa
             'border:none !important;" '
             'data-html={html} onload="{onload}" '

--- a/branca/element.py
+++ b/branca/element.py
@@ -335,6 +335,7 @@ class Figure(Element):
             iframe = (
             '<div style="width:{width};">'
             '<div style="position:relative;width:100%;height:0;padding-bottom:{ratio};">'  # noqa
+            '<span style="color:#565656">Make this Notebook Trusted to load map: File -> Trust Notebook</span>'
             '<iframe src="about:blank" style="position:absolute;width:100%;height:100%;left:0;top:0;'  # noqa
             'border:none !important;" '
             'data-html={html} onload="{onload}" '


### PR DESCRIPTION
Close https://github.com/python-visualization/folium/issues/1277

For Jupyter Notebooks we no longer store the data in the `src` attribute, but load it with Javascript on page load (see #66). This works fine, but requires Javascript to be enabled. Jupyter doesn't run Javascript on notebooks the user didn't run themselves or didn't trust explicitly. This means maps won't show if you open a notebook you got from the internet.

If a user executes a cell the map will show. A user can also trust the notebook, which will load the map.

This PR adds a message underneath the map that prompts the user to trust the notebook. If the map loads it will be placed on top of the message.

Notebook is not trusted, map doesn't load, message shows:
![image](https://user-images.githubusercontent.com/33519926/80274766-12d40280-86dd-11ea-841e-e28d734030da.png)

Notebook is trusted, map loads:
![image](https://user-images.githubusercontent.com/33519926/80274748-f9cb5180-86dc-11ea-98f3-141d481598c7.png)