### PR TITLE
Fix special char encoding in notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ examples/foo.html
 # documentation builds
 docs/_build
 
+geckodriver.exe
 geckodriver.log
 
 # Pycharm

--- a/branca/element.py
+++ b/branca/element.py
@@ -319,12 +319,20 @@ class Figure(Element):
         return self._template.render(this=self, kwargs=kwargs)
 
     def _repr_html_(self, **kwargs):
-        """Displays the Figure in a Jupyter notebook."""
-        # Base64-encoded HTML is stored in a data-html attribute, which is used to populate
-        # the iframe. This approach does not encounter the 2MB limit in Chrome for storing
-        # the HTML in the src attribute with a data URI. The alternative of using a srcdoc
-        # attribute is not supported in Microsoft Internet Explorer and Edge.
-        html = base64.b64encode(self.render(**kwargs).encode('utf8')).decode('utf8')
+        """Displays the Figure in a Jupyter notebook.
+
+        Base64-encoded HTML is stored in data-html attribute, which is used to populate
+        the iframe. This approach does not encounter the 2MB limit in Chrome for storing
+        the HTML in the src attribute with a data URI. The alternative of using a srcdoc
+        attribute is not supported in Microsoft Internet Explorer and Edge.
+
+        In JS we use `atob` to base64 decode, which cannot handle non-ascii bytes.
+        Use `raw_unicode_escape` which turns those characters into `'\\uxxxx'`
+
+        """
+        html = base64.b64encode(
+            self.render(**kwargs).encode('raw_unicode_escape')
+        ).decode('utf8')
         onload = (
             'this.contentDocument.open();'
             'this.contentDocument.write(atob(this.getAttribute(\'data-html\')));'

--- a/branca/element.py
+++ b/branca/element.py
@@ -10,6 +10,7 @@ import base64
 import json
 import warnings
 from collections import OrderedDict
+import urllib.parse
 from urllib.request import urlopen
 from uuid import uuid4
 
@@ -321,22 +322,18 @@ class Figure(Element):
     def _repr_html_(self, **kwargs):
         """Displays the Figure in a Jupyter notebook.
 
-        Base64-encoded HTML is stored in data-html attribute, which is used to populate
+        Percent-encoded HTML is stored in data-html attribute, which is used to populate
         the iframe. This approach does not encounter the 2MB limit in Chrome for storing
         the HTML in the src attribute with a data URI. The alternative of using a srcdoc
         attribute is not supported in Microsoft Internet Explorer and Edge.
 
-        In JS we use `atob` to base64 decode, which cannot handle characters that
-        exceed the range of a 8-bit byte (0x00~0xFF).
-        Use `raw_unicode_escape` which turns those characters into `'\\uxxxx'`
-
         """
-        html = base64.b64encode(
-            self.render(**kwargs).encode('raw_unicode_escape')
-        ).decode('utf8')
+        html = urllib.parse.quote(self.render(**kwargs))
         onload = (
             'this.contentDocument.open();'
-            'this.contentDocument.write(atob(this.getAttribute(\'data-html\')));'
+            'this.contentDocument.write('
+            '    decodeURIComponent(this.getAttribute(\'data-html\'))'
+            ');'
             'this.contentDocument.close();'
         )
 

--- a/branca/element.py
+++ b/branca/element.py
@@ -326,7 +326,8 @@ class Figure(Element):
         the HTML in the src attribute with a data URI. The alternative of using a srcdoc
         attribute is not supported in Microsoft Internet Explorer and Edge.
 
-        In JS we use `atob` to base64 decode, which cannot handle non-ascii bytes.
+        In JS we use `atob` to base64 decode, which cannot handle characters that
+        exceed the range of a 8-bit byte (0x00~0xFF).
         Use `raw_unicode_escape` which turns those characters into `'\\uxxxx'`
 
         """

--- a/tests/test_iframe.py
+++ b/tests/test_iframe.py
@@ -4,6 +4,7 @@
 Folium Element Module class IFrame
 ----------------------
 """
+import os
 
 import pytest
 from selenium.webdriver import Firefox
@@ -33,3 +34,29 @@ def test_rendering_utf8_iframe():
     driver.get('data:text/html,' + iframe.render())
     driver.switch_to.frame(0)
     assert u'Cerrahpaşa Tıp Fakültesi' in driver.page_source
+
+
+@pytest.mark.headless
+def test_rendering_figure_notebook():
+    """Verify special characters are correctly rendered in Jupyter notebooks."""
+    text = '5/7 %, Линейная улица, "\u00e9 Berdsk"'
+    figure = elem.Figure()
+    elem.Html(text).add_to(figure.html)
+    html = figure._repr_html_()
+
+    filepath = 'temp_test_rendering_figure_notebook.html'
+    filepath = os.path.abspath(filepath)
+    with open(filepath, 'w') as f:
+        f.write(html)
+
+    options = Options()
+    options.add_argument('-headless')
+    driver = Firefox(options=options)
+    try:
+        driver.get('file://' + filepath)
+        driver.switch_to.frame(0)
+        text_div = driver.find_element_by_css_selector('div')
+        assert text_div.text == text
+    finally:
+        os.remove(filepath)
+        driver.quit()


### PR DESCRIPTION
Close https://github.com/python-visualization/folium/issues/1320

When we base64 decode the iframe for in notebooks we use JS `atob`. This function doesn't handle characters with multiple code units as expected. Mitigate this by not using base64 encoding, but percent-encoding. On the JS side we can decode this with `decodeURIComponent` without issues.

Example:
```
>>> title = '5/7 %, Линейная улица, é "Berdsk"'
>>> title.encode('utf-8')
b'5/7 %, \xd0\x9b\xd0\xb8\xd0\xbd\xd0\xb5\xd0\xb9\xd0\xbd\xd0\xb0\xd1\x8f \xd1\x83\xd0\xbb\xd0\xb8\xd1\x86\xd0\xb0, \xc3\xa9 "Berdsk"'
>>> urllib.parse.quote(title)
'5/7%20%25%2C%20%D0%9B%D0%B8%D0%BD%D0%B5%D0%B9%D0%BD%D0%B0%D1%8F%20%D1%83%D0%BB%D0%B8%D1%86%D0%B0%2C%20%C3%A9%20%22Berdsk%22'

```

--- To do ---
- [x] Add a test case