### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ pkg_data = {
 }
 pkgs = ["branca"]
 
-LICENSE = read("LICENSE.txt")
+LICENSE = "MIT"
 long_description = "{}".format(read("README.md"))
 
 # Dependencies.


### PR DESCRIPTION
Fix the wrong data in the license argument.

In our company, we use a tool to detect license issues (http://www.blackducksoftware.com/). It seems that the branca package 0.4.1 is wrongly detected because of the license data of the package.
Pypi also doesn't detect well the license because of the same problem.

`license` parameter for the `setup` function of the `setuptools` package uses a simple string and not the complete license file.

If we really want to embed the license file, there is 2 other parameters to do that according to the official documentation package (https://setuptools.readthedocs.io/en/latest/setuptools.html#metadata):

Key | Aliases | Type | Minimum Version | Notes
-- | -- | -- | -- | --
license |   | str |   |  
license_file |   | str |   |  
license_files |   | list-comma |   |  


