### PR TITLE
Removed misleading info in docstring

### DIFF
--- a/branca/element.py
+++ b/branca/element.py
@@ -408,10 +408,10 @@ class Html(Element):
         (suitable for embedding html-ready code)
     width : int or str, default '100%'
         The width of the output div element.
-        Ex: 120 , '120px', '80%'
+        Ex: 120 , '80%'
     height : int or str, default '100%'
         The height of the output div element.
-        Ex: 120 , '120px', '80%'
+        Ex: 120 , '80%'
     """
     _template = Template(
         '<div id="{{this.get_name()}}" '


### PR DESCRIPTION
In _parse_size there are only two cases:
if input is float or int -> consider it as pixel measure
if input is string -> parse it as percentage.
If '300px' is set as parameter, the exception "ValueError: Cannot parse value '300px' as '%'" is raised.