### PR TITLE
Make Element class pickleable

### DIFF
--- a/branca/element.py
+++ b/branca/element.py
@@ -61,16 +61,16 @@ class Element(object):
             self._template = ENV.get_template(template_name)
 
     def __getstate__(self):
-        """Modify object state when pickling the object
+        """Modify object state when pickling the object.
         jinja2 Environment cannot be pickled, so set
-        the ._env attribute to None. This will be re-populated
+        the ._env attribute to None. This will be added back
         when unpickling (see __setstate__)
         """
-        state = self.__dict__.copy()
+        state: dict = self.__dict__.copy()
         state["_env"] = None
         return state
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: dict):
         """Re-add ._env attribute when unpickling"""
         state["_env"] = ENV
         self.__dict__.update(state)

--- a/branca/element.py
+++ b/branca/element.py
@@ -60,6 +60,21 @@ class Element(object):
         elif template_name is not None:
             self._template = ENV.get_template(template_name)
 
+    def __getstate__(self):
+        """Modify object state when pickling the object
+        jinja2 Environment cannot be pickled, so set
+        the ._env attribute to None. This will be re-populated
+        when unpickling (see __setstate__)
+        """
+        state = self.__dict__.copy()
+        state["_env"] = None
+        return state
+
+    def __setstate__(self, state):
+        """Re-add ._env attribute when unpickling"""
+        state["_env"] = ENV
+        self.__dict__.update(state)
+
     def get_name(self):
         """Returns a string representation of the object.
         This string has to be unique and to be a python and


### PR DESCRIPTION
Make `Element` class (`branca.element.Element`) pickleable by stripping its ._env attribute when pickling and re-adding it when unpickling. This should address two related issues in `folium`: python-visualization/folium#878 and python-visualization/folium#796 and has the added implication of being able to create elements concurrently, e.g. using `multiprocessing.Pool`.