### PR TITLE
Speed up UUID creation for `Element._id`

### DIFF
--- a/branca/element.py
+++ b/branca/element.py
@@ -61,16 +61,16 @@ class Element(object):
             self._template = ENV.get_template(template_name)
 
     def __getstate__(self):
-        """Modify object state when pickling the object
+        """Modify object state when pickling the object.
         jinja2 Environment cannot be pickled, so set
-        the ._env attribute to None. This will be re-populated
+        the ._env attribute to None. This will be added back
         when unpickling (see __setstate__)
         """
-        state = self.__dict__.copy()
+        state: dict = self.__dict__.copy()
         state["_env"] = None
         return state
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: dict):
         """Re-add ._env attribute when unpickling"""
         state["_env"] = ENV
         self.__dict__.update(state)

--- a/branca/element.py
+++ b/branca/element.py
@@ -60,6 +60,21 @@ class Element(object):
         elif template_name is not None:
             self._template = ENV.get_template(template_name)
 
+    def __getstate__(self):
+        """Modify object state when pickling the object
+        jinja2 Environment cannot be pickled, so set
+        the ._env attribute to None. This will be re-populated
+        when unpickling (see __setstate__)
+        """
+        state = self.__dict__.copy()
+        state["_env"] = None
+        return state
+
+    def __setstate__(self, state):
+        """Re-add ._env attribute when unpickling"""
+        state["_env"] = ENV
+        self.__dict__.update(state)
+
     def get_name(self):
         """Returns a string representation of the object.
         This string has to be unique and to be a python and

--- a/branca/element.py
+++ b/branca/element.py
@@ -12,7 +12,8 @@ import json
 import warnings
 from collections import OrderedDict
 from urllib.request import urlopen
-from uuid import uuid4
+from binascii import hexlify
+from os import urandom
 
 from jinja2 import Environment, PackageLoader, Template
 
@@ -50,7 +51,7 @@ class Element(object):
 
     def __init__(self, template=None, template_name=None):
         self._name = 'Element'
-        self._id = uuid4().hex
+        self._id = hexlify(urandom(16)).decode()
         self._env = ENV
         self._children = OrderedDict()
         self._parent = None


### PR DESCRIPTION
`uuid.uuid4().hex`, used in `Element.__init__` to define `self._id`, is considerably slower than `binascii.hexlify(os.urandom(16)).decode()`. `uuid4` uses `os.urandom(16)` under the hood when creating a cryptographically-secure UUID, so creating UUIDs for `Element`-class objects using `hexlify` leads to a dramatic speed-up (I found about ~60%), which has implications for subclasses of `Element`. No new requirements are needed as `binascii` is already in the Python standard library, so this is essentially a free, pretty big speed bump (especially when considering that some `Element` subclasses in `folium` themselves create child instances of `Element` when instantiated).

- `self._id = uuid4().hex`:
```
In [1]: from branca.element import Element
   ...: %timeit -n 1000000 Element()
2.5 µs ± 8.56 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

- `self._id = hexlify(urandom(16)).decode()`:
```
In [1]: from branca.element import Element
   ...: %timeit -n 1000000 Element()
1.06 µs ± 1.86 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

```