### PR TITLE
allow colorbar ticks at arbitrary position

### DIFF
--- a/branca/colormap.py
+++ b/branca/colormap.py
@@ -84,13 +84,15 @@ class ColorMap(MacroElement):
         self.caption = caption
         self.index = [vmin, vmax]
         self.max_labels = max_labels
+        self.tick_labels = None
 
     def render(self, **kwargs):
         """Renders the HTML representation of the element."""
         self.color_domain = [self.vmin + (self.vmax-self.vmin) * k/499. for
                              k in range(500)]
         self.color_range = [self.__call__(x) for x in self.color_domain]
-        self.tick_labels = legend_scaler(self.index, self.max_labels)
+        if self.tick_labels is None:
+            self.tick_labels = legend_scaler(self.index, self.max_labels)
 
         super(ColorMap, self).render(**kwargs)
 
@@ -185,11 +187,13 @@ class LinearColormap(ColorMap):
         The maximal value for the colormap.
         Values higher than `vmax` will be bound directly to `colors[-1]`.
     max_labels : int, default 10
-        Maximum number of legend tick labels"""
-
-    def __init__(self, colors, index=None, vmin=0., vmax=1., caption='', max_labels=10):
+        Maximum number of legend tick labels
+    tick_labels: list of floats, default None
+        If given, used as the positions of ticks."""
+    def __init__(self, colors, index=None, vmin=0., vmax=1., caption='', max_labels=10, tick_labels=None):
         super(LinearColormap, self).__init__(vmin=vmin, vmax=vmax,
                                              caption=caption, max_labels=max_labels)
+        self.tick_labels = tick_labels
 
         n = len(colors)
         if n < 2:
@@ -332,7 +336,7 @@ class LinearColormap(ColorMap):
         caption = self.caption
 
         return StepColormap(colors, index=index, vmin=index[0], vmax=index[-1], caption=caption,
-                            max_labels=max_labels)
+                            max_labels=max_labels, tick_labels=self.tick_labels)
 
     def scale(self, vmin=0., vmax=1., max_labels=10):
         """Transforms the colorscale so that the minimal and maximal values
@@ -375,11 +379,13 @@ class StepColormap(ColorMap):
         Values higher than `vmax` will be bound directly to `colors[-1]`.
     max_labels : int, default 10
         Maximum number of legend tick labels
-
+    tick_labels: list of floats, default None
+        If given, used as the positions of ticks.
     """
-    def __init__(self, colors, index=None, vmin=0., vmax=1., caption='', max_labels=10):
+    def __init__(self, colors, index=None, vmin=0., vmax=1., caption='', max_labels=10, tick_labels=None):
         super(StepColormap, self).__init__(vmin=vmin, vmax=vmax,
                                            caption=caption, max_labels=max_labels)
+        self.tick_labels = tick_labels
 
         n = len(colors)
         if n < 1:


### PR DESCRIPTION
This extend the `ColorMap` and its successors `LinearColormap` and `StepColormap` so that one may specify the positions of ticks to display independently of the `index` parameter. Currently the `index` parameter is used both to determine the color scale and as the location of the legend labels.
It is possible that the two roles are better to be separated. For example, one decided to split colors by the percentile values of the data, which would result in any numeric values. However, for the visualization purpose, numbers shown in the color bar are better to be "good" numbers such as 0, 50, 100. For example, this discussion is related to this feature: https://github.com/python-visualization/folium/issues/1374.

This PR enables this feature by an adding additional argument `tick_labels` to `LinearColormap` and `StepColormap`, which is used as the tick positions. The default value is `None`, for which the current behavior is maintained. This logic is implemented in the `ColorMap.render` method.

In addition the `LinearColormap.to_step` method is updated so that the `tick_labels` attribute is maintained to the result.

Examples:

```python
import folium
from branca.colormap import LinearColormap
      
colormap = LinearColormap(["blue", "yellow", "red"], index=[1, 10, 100], vmin=1, vmax=100,
                          tick_labels=[30, 80, 150])
m = folium.Map(location=[48, -102], zoom_start=3)
colormap.add_to(m)
m
```
![Screenshot_2022-08-16_01-44-14](https://user-images.githubusercontent.com/12293919/184678188-dac3163d-2882-44ce-9ffc-0cb2b437dde3.png)


```python
import folium
from branca.colormap import StepColormap
      
colormap = StepColormap(["blue", "yellow", "red"], index=[1, 10, 100], vmin=1, vmax=100,
                        tick_labels=[30, 80, 150])
m = folium.Map(location=[48, -102], zoom_start=3)
colormap.add_to(m)
m
```
![Screenshot_2022-08-16_01-43-55](https://user-images.githubusercontent.com/12293919/184678216-e1b5c79b-6a28-43af-b682-fbe8ab3cbb09.png)

