### PR TITLE
Update setuptools keys in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,8 +20,8 @@ markers =
     headless: mark headless tests (deselect with '-m "not headless"')
 
 [metadata]
-description-file = README.rst
-license_file = LICENSE.txt
+long_description = README.md
+license_files = LICENSE.txt
 
 [check-manifest]
 ignore = 


### PR DESCRIPTION
Follow up on https://github.com/python-visualization/branca/pull/98

> description-file or description_file are both not supported keys: https://setuptools.pypa.io/en/latest/userguide/declarative_config.html. Instead we should use long_description. See this Stackoverflow answer: https://stackoverflow.com/questions/60084128/does-description-file-in-setup-cfg-section-metadata-have-any-effect.

> Also, license_file should be license_files.