### PR TITLE
escape colormap caption

### DIFF
--- a/branca/templates/color_scale.js
+++ b/branca/templates/color_scale.js
@@ -51,5 +51,5 @@
     {{this.get_name()}}.g.call({{this.get_name()}}.xAxis).append("text")
         .attr("class", "caption")
         .attr("y", 21)
-        .text('{{ this.caption }}');
+        .text({{ this.caption|tojson }});
 {% endmacro %}


### PR DESCRIPTION
Fix https://github.com/python-visualization/branca/issues/111

Currently the caption of a colormap is not escaped, which means it breaks when an apostrophe is included.

Use Jinja2's `tojson` to convert to an escaped string.

![afbeelding](https://user-images.githubusercontent.com/33519926/200128527-29541792-d553-4026-84e1-ac0143979752.png)

![afbeelding](https://user-images.githubusercontent.com/33519926/200128506-a7d62319-0ee7-43fd-85e2-629a0a2b6ae0.png)
