### PR TITLE
fix calculation of color index

### DIFF
--- a/branca/colormap.py
+++ b/branca/colormap.py
@@ -270,7 +270,9 @@ class LinearColormap(ColorMap):
         if x >= self.index[-1]:
             return self.colors[-1]
 
-        i = len([u for u in self.index if u < x])  # 0 < i < n.
+        # get the index of the first entry in self.index that is larger than x
+        i = next(i for i, v in enumerate(self.index) if v > x)
+
         if self.index[i - 1] < self.index[i]:
             p = (x - self.index[i - 1]) * 1.0 / (self.index[i] - self.index[i - 1])
         elif self.index[i - 1] == self.index[i]:
@@ -496,6 +498,8 @@ class StepColormap(ColorMap):
         if index is None:
             self.index = [vmin + (vmax - vmin) * i * 1.0 / n for i in range(n + 1)]
         else:
+            if any(index[i] > index[i+1] for i in range(len(index)-1)):
+                raise ValueError("The value in index must be in ascending order")
             self.index = list(index)
         self.colors = [_parse_color(x) for x in colors]
 
@@ -510,8 +514,12 @@ class StepColormap(ColorMap):
         if x >= self.index[-1]:
             return self.colors[-1]
 
-        i = len([u for u in self.index if u < x])  # 0 < i < n.
-        return tuple(self.colors[i - 1])
+        # get the index of the first entry in self.index that is larger than x
+        # subtract 1 to get the index of the last entry that is less or equal to x
+        i = next(i for i, v in enumerate(self.index) if v > x) - 1
+
+        # return the color at index i
+        return tuple(self.colors[i])
 
     def to_linear(self, index=None, max_labels=10):
         """

--- a/branca/colormap.py
+++ b/branca/colormap.py
@@ -498,7 +498,7 @@ class StepColormap(ColorMap):
         if index is None:
             self.index = [vmin + (vmax - vmin) * i * 1.0 / n for i in range(n + 1)]
         else:
-            if any(index[i] > index[i+1] for i in range(len(index)-1)):
+            if any(index[i] > index[i + 1] for i in range(len(index) - 1)):
                 raise ValueError("The value in index must be in ascending order")
             self.index = list(index)
         self.colors = [_parse_color(x) for x in colors]


### PR DESCRIPTION
The current code returns erroneous colors.
To make it clear I took the current implementation and put it into a separate function

```python
def new_implementation(value):
    if value <= index[0]:
        return 0
    if value >= index[-1]:
        return len(index) - 1
    return next(i for i, v in enumerate(color_map.index) if v > value) -1

def current_implementation(value):
    if value <= index[0]:
        return 0
    if value >= index[-1]:
        return len(index) - 1
    return len([u for u in index if u < value]) - 1

index = [1, 2, 4]
colors = ["black", 'purple', 'red']

print("value", "current implementation", "new implementation")
for i in range(-2, 5):
    print(i, "\t", current_implementation(i), "\t", new_implementation(i)) 
```

returns:

```
value current_implementation new_implementation
-2 	 0 	 0
-1 	 0 	 0
0 	 0 	 0
1 	 0 	 0
2 	 0 	 1
3 	 1 	 1
4 	 2 	 2
5 	 2 	 2

```

you will notice that for value `2` the current implementation would return color `0`, even though value `2` is at index `1` in `index`.

Or for 

```
index = [2, 4, 5]
```

this returns 
```
value current_implementation new_implementation
-2 	 0 	 0
-1 	 0 	 0
0 	 0 	 0
1 	 0 	 0
2 	 0 	 0
3 	 0 	 0
4 	 0 	 1
5 	 2 	 2
6 	 2 	 2
7 	 2 	 2
```

i.e. for index `4` we get color `0` and for index `5` color `2`. Color `1` is never returned though it should be returned vor value `4` 


Last but not least I added a check on init to make sure the index is in order