### PR TITLE
Make _parse_size robust to already parsed values

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,7 @@
 0.7.0
 ~~~~~
-- StepColormap: inclusive lower bound (@MxMartin #141) 
-- Add color schemes: plasma, inferno, magma (@FlorinAndrei #131) 
+- StepColormap: inclusive lower bound (@MxMartin #141)
+- Add color schemes: plasma, inferno, magma (@FlorinAndrei #131)
 - Allow branca ColorMap in write_png (@Conengmo #126)
 - More flexible _parse_size (@Conengmo #125)
 

--- a/branca/utilities.py
+++ b/branca/utilities.py
@@ -414,6 +414,9 @@ def _parse_size(value):
             raise ValueError(
                 f"Cannot parse {value!r}, it should be a number followed by a unit.",
             )
+    elif isinstance(value, tuple) and isinstance(value[0], (int, float)) and isinstance(value[1], str):
+        # value had been already parsed
+        return value
     else:
         raise TypeError(
             f"Cannot parse {value!r}, it should be a number or a string containing a number and a unit.",

--- a/branca/utilities.py
+++ b/branca/utilities.py
@@ -414,7 +414,11 @@ def _parse_size(value):
             raise ValueError(
                 f"Cannot parse {value!r}, it should be a number followed by a unit.",
             )
-    elif isinstance(value, tuple) and isinstance(value[0], (int, float)) and isinstance(value[1], str):
+    elif (
+        isinstance(value, tuple)
+        and isinstance(value[0], (int, float))
+        and isinstance(value[1], str)
+    ):
         # value had been already parsed
         return value
     else:

--- a/branca/utilities.py
+++ b/branca/utilities.py
@@ -420,7 +420,7 @@ def _parse_size(value):
         and isinstance(value[1], str)
     ):
         # value had been already parsed
-        return value
+        return (float(value[0]), value[1])
     else:
         raise TypeError(
             f"Cannot parse {value!r}, it should be a number or a string containing a number and a unit.",

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -116,6 +116,8 @@ def test_color_avoid_unexpected_error():
         ("100%   ", (100.0, "%")),
         ("3 vw", (3.0, "vw")),
         ("3.14 rem", (3.14, "rem")),
+        ((1, "px"), (1.0, "px")),
+        ((80.0, "%"), (80.0, "%")),
     ],
 )
 def test_parse_size(value, result):
@@ -128,6 +130,7 @@ def test_parse_size(value, result):
         "what?",
         "1.21 jigawatts",
         ut._parse_size,
+        (1.21, 4.9),
     ],
 )
 def test_parse_size_exceptions(value):


### PR DESCRIPTION
This minor change is NOT needed if we want to be able to unpickle a folium Map afterwards, it is only there for code robustness.