### PR TITLE
Add type hints

### DIFF
--- a/.github/workflows/test_mypy.yml
+++ b/.github/workflows/test_mypy.yml
@@ -1,6 +1,10 @@
 name: Mypy type hint checks
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   run:

--- a/.github/workflows/test_mypy.yml
+++ b/.github/workflows/test_mypy.yml
@@ -1,0 +1,29 @@
+name: Mypy type hint checks
+
+on: [push, pull_request]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup Micromamba env
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-name: TEST
+        create-args: >-
+          python=3
+          --file requirements.txt
+          --file requirements-dev.txt
+
+    - name: Install branca from source
+      shell: bash -l {0}
+      run: |
+        python -m pip install -e . --no-deps --force-reinstall
+
+    - name: Mypy test
+      shell: bash -l {0}
+      run: |
+        mypy branca

--- a/branca/colormap.py
+++ b/branca/colormap.py
@@ -112,10 +112,14 @@ class ColorMap(MacroElement):
         self.vmin = vmin
         self.vmax = vmax
         self.caption = caption
+<<<<<<< HEAD
         self.text_color = text_color
         self.index = [vmin, vmax]
+=======
+        self.index: List[float] = [vmin, vmax]
+>>>>>>> ec6251d... utilities.py wip
         self.max_labels = max_labels
-        self.tick_labels: Optional[Sequence[float]] = None
+        self.tick_labels: Optional[Sequence[Union[float, str]]] = None
 
         self.width = 450
         self.height = 40

--- a/branca/colormap.py
+++ b/branca/colormap.py
@@ -245,42 +245,42 @@ class ColorMap(MacroElement):
 
 class LinearColormap(ColorMap):
     """Creates a ColorMap based on linear interpolation of a set of colors
-        over a given index.
+    over a given index.
 
-        Parameters
-        ----------
+    Parameters
+    ----------
 
-        colors : list-like object with at least two colors.
-            The set of colors to be used for interpolation.
-            Colors can be provided in the form:
-            * tuples of RGBA ints between 0 and 255 (e.g: `(255, 255, 0)` or
-            `(255, 255, 0, 255)`)
-            * tuples of RGBA floats between 0. and 1. (e.g: `(1.,1.,0.)` or
-            `(1., 1., 0., 1.)`)
-            * HTML-like string (e.g: `"#ffff00`)
-            * a color name or shortcut (e.g: `"y"` or `"yellow"`)
-        index : list of floats, default None
-            The values corresponding to each color.
-            It has to be sorted, and have the same length as `colors`.
-            If None, a regular grid between `vmin` and `vmax` is created.
-        vmin : float, default 0.
-            The minimal value for the colormap.
-            Values lower than `vmin` will be bound directly to `colors[0]`.
-        vmax : float, default 1.
-            The maximal value for the colormap.
-            Values higher than `vmax` will be bound directly to `colors[-1]`.
-    <<<<<<< HEAD
-        caption: str
-            A caption to draw with the colormap.
-        text_color: str, default "black"
-            The color for the text.
-    =======
-        caption : str, default ""
-    >>>>>>> a7239e8... Update colormap.py
-        max_labels : int, default 10
-            Maximum number of legend tick labels
-        tick_labels: list of floats, default None
-            If given, used as the positions of ticks."""
+    colors : list-like object with at least two colors.
+        The set of colors to be used for interpolation.
+        Colors can be provided in the form:
+        * tuples of RGBA ints between 0 and 255 (e.g: `(255, 255, 0)` or
+        `(255, 255, 0, 255)`)
+        * tuples of RGBA floats between 0. and 1. (e.g: `(1.,1.,0.)` or
+        `(1., 1., 0., 1.)`)
+        * HTML-like string (e.g: `"#ffff00`)
+        * a color name or shortcut (e.g: `"y"` or `"yellow"`)
+    index : list of floats, default None
+        The values corresponding to each color.
+        It has to be sorted, and have the same length as `colors`.
+        If None, a regular grid between `vmin` and `vmax` is created.
+    vmin : float, default 0.
+        The minimal value for the colormap.
+        Values lower than `vmin` will be bound directly to `colors[0]`.
+    vmax : float, default 1.
+        The maximal value for the colormap.
+        Values higher than `vmax` will be bound directly to `colors[-1]`.
+<<<<<<< HEAD
+    caption: str
+        A caption to draw with the colormap.
+    text_color: str, default "black"
+        The color for the text.
+=======
+    caption : str, default ""
+>>>>>>> a7239e8... Update colormap.py
+    max_labels : int, default 10
+        Maximum number of legend tick labels
+    tick_labels: list of floats, default None
+        If given, used as the positions of ticks."""
 
     def __init__(
         self,

--- a/branca/colormap.py
+++ b/branca/colormap.py
@@ -9,51 +9,69 @@ Utility module for dealing with colormaps.
 import json
 import math
 import os
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 from jinja2 import Template
 
 from branca.element import ENV, Figure, JavascriptLink, MacroElement
 from branca.utilities import legend_scaler
 
-rootpath = os.path.abspath(os.path.dirname(__file__))
+rootpath: str = os.path.abspath(os.path.dirname(__file__))
 
 with open(os.path.join(rootpath, "_cnames.json")) as f:
-    _cnames = json.loads(f.read())
+    _cnames: Dict[str, str] = json.loads(f.read())
 
 with open(os.path.join(rootpath, "_schemes.json")) as f:
-    _schemes = json.loads(f.read())
+    _schemes: Dict[str, List[str]] = json.loads(f.read())
 
 
-def _is_hex(x):
+TypeRGBInts = Tuple[int, int, int]
+TypeRGBFloats = Tuple[float, float, float]
+TypeRGBAInts = Tuple[int, int, int, int]
+TypeRGBAFloats = Tuple[float, float, float, float]
+TypeAnyColorType = Union[TypeRGBInts, TypeRGBFloats, TypeRGBAInts, TypeRGBAFloats, str]
+
+
+def _is_hex(x: str) -> bool:
     return x.startswith("#") and len(x) == 7
 
 
-def _parse_hex(color_code):
+def _parse_hex(color_code: str) -> TypeRGBAFloats:
     return (
-        int(color_code[1:3], 16),
-        int(color_code[3:5], 16),
-        int(color_code[5:7], 16),
+        _color_int_to_float(int(color_code[1:3], 16)),
+        _color_int_to_float(int(color_code[3:5], 16)),
+        _color_int_to_float(int(color_code[5:7], 16)),
+        1.0,
     )
 
 
-def _parse_color(x):
+def _color_int_to_float(x: int) -> float:
+    """Convert an integer between 0 and 255 to a float between 0. and 1.0"""
+    return x / 255.0
+
+
+def _color_float_to_int(x: float) -> int:
+    """Convert a float between 0. and 1.0 to an integer between 0 and 255"""
+    return int(x * 255.9999)
+
+
+def _parse_color(x: Union[tuple, list, str]) -> TypeRGBAFloats:
+    color_tuple: TypeRGBAFloats
     if isinstance(x, (tuple, list)):
-        color_tuple = tuple(x)[:4]
-    elif isinstance(x, (str, bytes)) and _is_hex(x):
+        color_tuple = tuple(tuple(x) + (1.0,))[:4]  # type: ignore
+    elif isinstance(x, str) and _is_hex(x):
         color_tuple = _parse_hex(x)
-    elif isinstance(x, (str, bytes)):
+    elif isinstance(x, str):
         cname = _cnames.get(x.lower(), None)
         if cname is None:
             raise ValueError(f"Unknown color {cname!r}.")
         color_tuple = _parse_hex(cname)
     else:
         raise ValueError(f"Unrecognized color code {x!r}")
-    if max(color_tuple) > 1.0:
-        color_tuple = tuple(u / 255.0 for u in color_tuple)
-    return tuple(map(float, (color_tuple + (1.0,))[:4]))
+    return color_tuple
 
 
-def _base(x):
+def _base(x: float) -> float:
     if x > 0:
         base = pow(10, math.floor(math.log10(x)))
         return round(x / base) * base
@@ -78,15 +96,15 @@ class ColorMap(MacroElement):
         Maximum number of legend tick labels
     """
 
-    _template = ENV.get_template("color_scale.js")
+    _template: Template = ENV.get_template("color_scale.js")
 
     def __init__(
         self,
-        vmin=0.0,
-        vmax=1.0,
-        caption="",
-        text_color="black",
-        max_labels=10,
+        vmin: float = 0.0,
+        vmax: float = 1.0,
+        caption: str = "",
+        text_color: str = "black",
+        max_labels: int = 10,
     ):
         super().__init__()
         self._name = "ColorMap"
@@ -97,7 +115,7 @@ class ColorMap(MacroElement):
         self.text_color = text_color
         self.index = [vmin, vmax]
         self.max_labels = max_labels
-        self.tick_labels = None
+        self.tick_labels: Optional[Sequence[float]] = None
 
         self.width = 450
         self.height = 40
@@ -127,7 +145,7 @@ class ColorMap(MacroElement):
             name="d3",
         )  # noqa
 
-    def rgba_floats_tuple(self, x):
+    def rgba_floats_tuple(self, x: float) -> TypeRGBAFloats:
         """
         This class has to be implemented for each class inheriting from
         Colormap. This has to be a function of the form float ->
@@ -137,37 +155,37 @@ class ColorMap(MacroElement):
         """
         raise NotImplementedError
 
-    def rgba_bytes_tuple(self, x):
+    def rgba_bytes_tuple(self, x: float) -> TypeRGBAInts:
         """Provides the color corresponding to value `x` in the
         form of a tuple (R,G,B,A) with int values between 0 and 255.
         """
-        return tuple(int(u * 255.9999) for u in self.rgba_floats_tuple(x))
+        return tuple(_color_float_to_int(u) for u in self.rgba_floats_tuple(x))  # type: ignore
 
-    def rgb_bytes_tuple(self, x):
+    def rgb_bytes_tuple(self, x: float) -> TypeRGBInts:
         """Provides the color corresponding to value `x` in the
         form of a tuple (R,G,B) with int values between 0 and 255.
         """
         return self.rgba_bytes_tuple(x)[:3]
 
-    def rgb_hex_str(self, x):
+    def rgb_hex_str(self, x: float) -> str:
         """Provides the color corresponding to value `x` in the
         form of a string of hexadecimal values "#RRGGBB".
         """
         return "#%02x%02x%02x" % self.rgb_bytes_tuple(x)
 
-    def rgba_hex_str(self, x):
+    def rgba_hex_str(self, x: float) -> str:
         """Provides the color corresponding to value `x` in the
         form of a string of hexadecimal values "#RRGGBBAA".
         """
         return "#%02x%02x%02x%02x" % self.rgba_bytes_tuple(x)
 
-    def __call__(self, x):
+    def __call__(self, x: float) -> str:
         """Provides the color corresponding to value `x` in the
         form of a string of hexadecimal values "#RRGGBBAA".
         """
         return self.rgba_hex_str(x)
 
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         """Display the colormap in a Jupyter Notebook.
 
         Does not support all the class arguments.
@@ -264,14 +282,14 @@ class LinearColormap(ColorMap):
 
     def __init__(
         self,
-        colors,
-        index=None,
-        vmin=0.0,
-        vmax=1.0,
-        caption="",
-        text_color="black",
-        max_labels=10,
-        tick_labels=None,
+        colors: Sequence[TypeAnyColorType],
+        index: Optional[Sequence[float]] = None,
+        vmin: float = 0.0,
+        vmax: float = 1.0,
+        caption: str = "",
+        text_color: str = "black",
+        max_labels: int = 10,
+        tick_labels: Optional[Sequence[float]] = None,
     ):
         super().__init__(
             vmin=vmin,
@@ -289,9 +307,9 @@ class LinearColormap(ColorMap):
             self.index = [vmin + (vmax - vmin) * i * 1.0 / (n - 1) for i in range(n)]
         else:
             self.index = list(index)
-        self.colors = [_parse_color(x) for x in colors]
+        self.colors: List[TypeRGBAFloats] = [_parse_color(x) for x in colors]
 
-    def rgba_floats_tuple(self, x):
+    def rgba_floats_tuple(self, x: float) -> TypeRGBAFloats:
         """Provides the color corresponding to value `x` in the
         form of a tuple (R,G,B,A) with float values between 0. and 1.
         """
@@ -308,20 +326,20 @@ class LinearColormap(ColorMap):
         else:
             raise ValueError("Thresholds are not sorted.")
 
-        return tuple(
+        return tuple(  # type: ignore
             (1.0 - p) * self.colors[i - 1][j] + p * self.colors[i][j] for j in range(4)
         )
 
     def to_step(
         self,
-        n=None,
-        index=None,
-        data=None,
-        method=None,
-        quantiles=None,
-        round_method=None,
-        max_labels=10,
-    ):
+        n: Optional[int] = None,
+        index: Optional[Sequence[float]] = None,
+        data: Optional[Sequence[float]] = None,
+        method: Optional[str] = None,
+        quantiles: Optional[Sequence[float]] = None,
+        round_method: Optional[str] = None,
+        max_labels: int = 10,
+    ) -> "StepColormap":
         """Splits the LinearColormap into a StepColormap.
 
         Parameters
@@ -454,7 +472,12 @@ class LinearColormap(ColorMap):
             tick_labels=self.tick_labels,
         )
 
-    def scale(self, vmin=0.0, vmax=1.0, max_labels=10):
+    def scale(
+        self,
+        vmin: float = 0.0,
+        vmax: float = 1.0,
+        max_labels: int = 10,
+    ) -> "LinearColormap":
         """Transforms the colorscale so that the minimal and maximal values
         fit the given parameters.
         """
@@ -510,14 +533,14 @@ class StepColormap(ColorMap):
 
     def __init__(
         self,
-        colors,
-        index=None,
-        vmin=0.0,
-        vmax=1.0,
-        caption="",
-        text_color="black",
-        max_labels=10,
-        tick_labels=None,
+        colors: Sequence[TypeAnyColorType],
+        index: Optional[Sequence[float]] = None,
+        vmin: float = 0.0,
+        vmax: float = 1.0,
+        caption: str = "",
+        text_color: str = "black",
+        max_labels: int = 10,
+        tick_labels: Optional[Sequence[float]] = None,
     ):
         super().__init__(
             vmin=vmin,
@@ -535,9 +558,9 @@ class StepColormap(ColorMap):
             self.index = [vmin + (vmax - vmin) * i * 1.0 / n for i in range(n + 1)]
         else:
             self.index = list(index)
-        self.colors = [_parse_color(x) for x in colors]
+        self.colors: List[TypeRGBAFloats] = [_parse_color(x) for x in colors]
 
-    def rgba_floats_tuple(self, x):
+    def rgba_floats_tuple(self, x: float) -> TypeRGBAFloats:
         """
         Provides the color corresponding to value `x` in the
         form of a tuple (R,G,B,A) with float values between 0. and 1.
@@ -549,9 +572,13 @@ class StepColormap(ColorMap):
             return self.colors[-1]
 
         i = len([u for u in self.index if u <= x])  # 0 < i < n.
-        return tuple(self.colors[i - 1])
+        return self.colors[i - 1]
 
-    def to_linear(self, index=None, max_labels=10):
+    def to_linear(
+        self,
+        index: Optional[Sequence[float]] = None,
+        max_labels: int = 10,
+    ) -> LinearColormap:
         """
         Transforms the StepColormap into a LinearColormap.
 
@@ -584,7 +611,12 @@ class StepColormap(ColorMap):
             max_labels=max_labels,
         )
 
-    def scale(self, vmin=0.0, vmax=1.0, max_labels=10):
+    def scale(
+        self,
+        vmin: float = 0.0,
+        vmax: float = 1.0,
+        max_labels: int = 10,
+    ) -> "StepColormap":
         """Transforms the colorscale so that the minimal and maximal values
         fit the given parameters.
         """
@@ -611,7 +643,7 @@ class _LinearColormaps:
         for key, val in _schemes.items():
             setattr(self, key, LinearColormap(val))
 
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         return Template(
             """
         <table>
@@ -634,7 +666,7 @@ class _StepColormaps:
         for key, val in _schemes.items():
             setattr(self, key, StepColormap(val))
 
-    def _repr_html_(self):
+    def _repr_html_(self) -> str:
         return Template(
             """
         <table>

--- a/branca/colormap.py
+++ b/branca/colormap.py
@@ -56,19 +56,17 @@ def _color_float_to_int(x: float) -> int:
 
 
 def _parse_color(x: Union[tuple, list, str]) -> TypeRGBAFloats:
-    color_tuple: TypeRGBAFloats
     if isinstance(x, (tuple, list)):
-        color_tuple = tuple(tuple(x) + (1.0,))[:4]  # type: ignore
+        return tuple(tuple(x) + (1.0,))[:4]  # type: ignore
     elif isinstance(x, str) and _is_hex(x):
-        color_tuple = _parse_hex(x)
+        return _parse_hex(x)
     elif isinstance(x, str):
         cname = _cnames.get(x.lower(), None)
         if cname is None:
             raise ValueError(f"Unknown color {cname!r}.")
-        color_tuple = _parse_hex(cname)
+        return _parse_hex(cname)
     else:
         raise ValueError(f"Unrecognized color code {x!r}")
-    return color_tuple
 
 
 def _base(x: float) -> float:
@@ -275,10 +273,14 @@ class LinearColormap(ColorMap):
     vmax : float, default 1.
         The maximal value for the colormap.
         Values higher than `vmax` will be bound directly to `colors[-1]`.
+<<<<<<< HEAD
     caption: str
         A caption to draw with the colormap.
     text_color: str, default "black"
         The color for the text.
+=======
+    caption : str, default ""
+>>>>>>> a7239e8... Update colormap.py
     max_labels : int, default 10
         Maximum number of legend tick labels
     tick_labels: list of floats, default None
@@ -302,7 +304,7 @@ class LinearColormap(ColorMap):
             text_color=text_color,
             max_labels=max_labels,
         )
-        self.tick_labels = tick_labels
+        self.tick_labels: Optional[Sequence[float]] = tick_labels
 
         n = len(colors)
         if n < 2:
@@ -339,7 +341,7 @@ class LinearColormap(ColorMap):
         n: Optional[int] = None,
         index: Optional[Sequence[float]] = None,
         data: Optional[Sequence[float]] = None,
-        method: Optional[str] = None,
+        method: str = "linear",
         quantiles: Optional[Sequence[float]] = None,
         round_method: Optional[str] = None,
         max_labels: int = 10,
@@ -404,11 +406,7 @@ class LinearColormap(ColorMap):
                 max_ = max(data)
                 min_ = min(data)
                 scaled_cm = self.scale(vmin=min_, vmax=max_)
-                method = (
-                    "quantiles"
-                    if quantiles is not None
-                    else method if method is not None else "linear"
-                )
+                method = "quantiles" if quantiles is not None else method
                 if method.lower().startswith("lin"):
                     if n is None:
                         raise ValueError(msg)

--- a/branca/colormap.py
+++ b/branca/colormap.py
@@ -245,42 +245,42 @@ class ColorMap(MacroElement):
 
 class LinearColormap(ColorMap):
     """Creates a ColorMap based on linear interpolation of a set of colors
-    over a given index.
+        over a given index.
 
-    Parameters
-    ----------
+        Parameters
+        ----------
 
-    colors : list-like object with at least two colors.
-        The set of colors to be used for interpolation.
-        Colors can be provided in the form:
-        * tuples of RGBA ints between 0 and 255 (e.g: `(255, 255, 0)` or
-        `(255, 255, 0, 255)`)
-        * tuples of RGBA floats between 0. and 1. (e.g: `(1.,1.,0.)` or
-        `(1., 1., 0., 1.)`)
-        * HTML-like string (e.g: `"#ffff00`)
-        * a color name or shortcut (e.g: `"y"` or `"yellow"`)
-    index : list of floats, default None
-        The values corresponding to each color.
-        It has to be sorted, and have the same length as `colors`.
-        If None, a regular grid between `vmin` and `vmax` is created.
-    vmin : float, default 0.
-        The minimal value for the colormap.
-        Values lower than `vmin` will be bound directly to `colors[0]`.
-    vmax : float, default 1.
-        The maximal value for the colormap.
-        Values higher than `vmax` will be bound directly to `colors[-1]`.
-<<<<<<< HEAD
-    caption: str
-        A caption to draw with the colormap.
-    text_color: str, default "black"
-        The color for the text.
-=======
-    caption : str, default ""
->>>>>>> a7239e8... Update colormap.py
-    max_labels : int, default 10
-        Maximum number of legend tick labels
-    tick_labels: list of floats, default None
-        If given, used as the positions of ticks."""
+        colors : list-like object with at least two colors.
+            The set of colors to be used for interpolation.
+            Colors can be provided in the form:
+            * tuples of RGBA ints between 0 and 255 (e.g: `(255, 255, 0)` or
+            `(255, 255, 0, 255)`)
+            * tuples of RGBA floats between 0. and 1. (e.g: `(1.,1.,0.)` or
+            `(1., 1., 0., 1.)`)
+            * HTML-like string (e.g: `"#ffff00`)
+            * a color name or shortcut (e.g: `"y"` or `"yellow"`)
+        index : list of floats, default None
+            The values corresponding to each color.
+            It has to be sorted, and have the same length as `colors`.
+            If None, a regular grid between `vmin` and `vmax` is created.
+        vmin : float, default 0.
+            The minimal value for the colormap.
+            Values lower than `vmin` will be bound directly to `colors[0]`.
+        vmax : float, default 1.
+            The maximal value for the colormap.
+            Values higher than `vmax` will be bound directly to `colors[-1]`.
+    <<<<<<< HEAD
+        caption: str
+            A caption to draw with the colormap.
+        text_color: str, default "black"
+            The color for the text.
+    =======
+        caption : str, default ""
+    >>>>>>> a7239e8... Update colormap.py
+        max_labels : int, default 10
+            Maximum number of legend tick labels
+        tick_labels: list of floats, default None
+            If given, used as the positions of ticks."""
 
     def __init__(
         self,

--- a/branca/colormap.py
+++ b/branca/colormap.py
@@ -110,12 +110,8 @@ class ColorMap(MacroElement):
         self.vmin = vmin
         self.vmax = vmax
         self.caption = caption
-<<<<<<< HEAD
         self.text_color = text_color
-        self.index = [vmin, vmax]
-=======
         self.index: List[float] = [vmin, vmax]
->>>>>>> ec6251d... utilities.py wip
         self.max_labels = max_labels
         self.tick_labels: Optional[Sequence[Union[float, str]]] = None
 

--- a/branca/colormap.py
+++ b/branca/colormap.py
@@ -269,14 +269,10 @@ class LinearColormap(ColorMap):
     vmax : float, default 1.
         The maximal value for the colormap.
         Values higher than `vmax` will be bound directly to `colors[-1]`.
-<<<<<<< HEAD
     caption: str
         A caption to draw with the colormap.
     text_color: str, default "black"
         The color for the text.
-=======
-    caption : str, default ""
->>>>>>> a7239e8... Update colormap.py
     max_labels : int, default 10
         Maximum number of legend tick labels
     tick_labels: list of floats, default None

--- a/branca/element.py
+++ b/branca/element.py
@@ -184,8 +184,8 @@ class Element:
                 [
                     (name, child.to_dict(depth=depth - 1))
                     for name, child in self._children.items()
-                ],
-            )  # noqa
+                ]
+            )
         return out
 
     def to_json(self, depth: int = -1, **kwargs) -> str:
@@ -554,8 +554,8 @@ class Div(Figure):
         self._name = "Div"
 
         # Size Parameters.
-        self.width = _parse_size(width)
-        self.height = _parse_size(height)
+        self.width = _parse_size(width)  # type: ignore
+        self.height = _parse_size(height)  # type: ignore
         self.left = _parse_size(left)
         self.top = _parse_size(top)
         self.position = position
@@ -576,7 +576,7 @@ class Div(Figure):
         """Returns the root of the elements tree."""
         return self
 
-    def render(self, **kwargs) -> str:
+    def render(self, **kwargs):
         """Renders the HTML representation of the element."""
         figure = self._parent
         assert isinstance(figure, Figure), (
@@ -666,9 +666,7 @@ class IFrame(Element):
         html = super().render(**kwargs)
         html = "data:text/html;charset=utf-8;base64," + base64.b64encode(
             html.encode("utf8"),
-        ).decode(
-            "utf8",
-        )  # noqa
+        ).decode("utf8")
 
         if self.height is None:
             iframe = (
@@ -715,7 +713,7 @@ class MacroElement(Element):
         super().__init__()
         self._name = "MacroElement"
 
-    def render(self, **kwargs) -> str:
+    def render(self, **kwargs):
         """Renders the HTML representation of the element."""
         figure = self.get_root()
         assert isinstance(figure, Figure), (

--- a/branca/element.py
+++ b/branca/element.py
@@ -583,6 +583,9 @@ class Div(Figure):
             "You cannot render this Element " "if it is not in a Figure."
         )
 
+        for name, element in self._children.items():
+            element.render(**kwargs)
+
         for name, element in self.header._children.items():
             figure.header.add_child(element, name=name)
 
@@ -600,8 +603,6 @@ class Div(Figure):
         script = self._template.module.__dict__.get("script", None)
         if script is not None:
             figure.script.add_child(Element(script(self, kwargs)), name=self.get_name())
-
-        return figure.render()
 
     def _repr_html_(self, **kwargs) -> str:
         """Displays the Div in a Jupyter notebook."""
@@ -733,4 +734,5 @@ class MacroElement(Element):
         if script is not None:
             figure.script.add_child(Element(script(self, kwargs)), name=self.get_name())
 
-        return figure.render()
+        for name, element in self._children.items():
+            element.render(**kwargs)

--- a/branca/element.py
+++ b/branca/element.py
@@ -14,11 +14,12 @@ from collections import OrderedDict
 from html import escape
 from os import urandom
 from pathlib import Path
+from typing import BinaryIO, List, Optional, Tuple, Type, Union
 from urllib.request import urlopen
 
 from jinja2 import Environment, PackageLoader, Template
 
-from .utilities import _camelify, _parse_size, none_max, none_min
+from .utilities import TypeParseSize, _camelify, _parse_size, none_max, none_min
 
 ENV = Environment(loader=PackageLoader("branca", "templates"))
 
@@ -45,26 +46,30 @@ class Element:
 
     """
 
-    _template = Template(
+    _template: Template = Template(
         "{% for name, element in this._children.items() %}\n"
         "    {{element.render(**kwargs)}}"
         "{% endfor %}",
     )
 
-    def __init__(self, template=None, template_name=None):
-        self._name = "Element"
-        self._id = hexlify(urandom(16)).decode()
-        self._children = OrderedDict()
-        self._parent = None
-        self._template_str = template
-        self._template_name = template_name
+    def __init__(
+        self,
+        template: Optional[str] = None,
+        template_name: Optional[str] = None,
+    ):
+        self._name: str = "Element"
+        self._id: str = hexlify(urandom(16)).decode()
+        self._children: OrderedDict[str, Element] = OrderedDict()
+        self._parent: Optional[Element] = None
+        self._template_str: Optional[str] = template
+        self._template_name: Optional[str] = template_name
 
         if template is not None:
             self._template = Template(template)
         elif template_name is not None:
             self._template = ENV.get_template(template_name)
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict:
         """Modify object state when pickling the object.
 
         jinja2 Templates cannot be pickled, so remove the instance attribute
@@ -83,7 +88,7 @@ class Element:
 
         self.__dict__.update(state)
 
-    def get_name(self):
+    def get_name(self) -> str:
         """Returns a string representation of the object.
         This string has to be unique and to be a python and
         javascript-compatible
@@ -91,13 +96,13 @@ class Element:
         """
         return _camelify(self._name) + "_" + self._id
 
-    def _get_self_bounds(self):
+    def _get_self_bounds(self) -> List[List[Optional[float]]]:
         """Computes the bounds of the object itself (not including it's children)
         in the form [[lat_min, lon_min], [lat_max, lon_max]]
         """
         return [[None, None], [None, None]]
 
-    def get_bounds(self):
+    def get_bounds(self) -> List[List[Optional[float]]]:
         """Computes the bounds of the object and all it's children
         in the form [[lat_min, lon_min], [lat_max, lon_max]].
         """
@@ -117,7 +122,12 @@ class Element:
             ]
         return bounds
 
-    def add_children(self, child, name=None, index=None):
+    def add_children(
+        self,
+        child: "Element",
+        name: Optional[str] = None,
+        index: Optional[int] = None,
+    ) -> "Element":
         """Add a child."""
         warnings.warn(
             "Method `add_children` is deprecated. Please use `add_child` instead.",
@@ -126,7 +136,12 @@ class Element:
         )
         return self.add_child(child, name=name, index=index)
 
-    def add_child(self, child, name=None, index=None):
+    def add_child(
+        self,
+        child: "Element",
+        name: Optional[str] = None,
+        index: Optional[int] = None,
+    ) -> "Element":
         """Add a child."""
         if name is None:
             name = child.get_name()
@@ -139,13 +154,24 @@ class Element:
         child._parent = self
         return self
 
-    def add_to(self, parent, name=None, index=None):
+    def add_to(
+        self,
+        parent: "Element",
+        name: Optional[str] = None,
+        index: Optional[int] = None,
+    ) -> "Element":
         """Add element to a parent."""
         parent.add_child(self, name=name, index=index)
         return self
 
-    def to_dict(self, depth=-1, ordered=True, **kwargs):
+    def to_dict(
+        self,
+        depth: int = -1,
+        ordered: bool = True,
+        **kwargs,
+    ) -> Union[dict, OrderedDict]:
         """Returns a dict representation of the object."""
+        dict_fun: Type[Union[dict, OrderedDict]]
         if ordered:
             dict_fun = OrderedDict
         else:
@@ -162,22 +188,27 @@ class Element:
             )  # noqa
         return out
 
-    def to_json(self, depth=-1, **kwargs):
+    def to_json(self, depth: int = -1, **kwargs) -> str:
         """Returns a JSON representation of the object."""
         return json.dumps(self.to_dict(depth=depth, ordered=True), **kwargs)
 
-    def get_root(self):
+    def get_root(self) -> "Element":
         """Returns the root of the elements tree."""
         if self._parent is None:
             return self
         else:
             return self._parent.get_root()
 
-    def render(self, **kwargs):
+    def render(self, **kwargs) -> str:
         """Renders the HTML representation of the element."""
         return self._template.render(this=self, kwargs=kwargs)
 
-    def save(self, outfile, close_file=True, **kwargs):
+    def save(
+        self,
+        outfile: Union[str, bytes, Path, BinaryIO],
+        close_file: bool = True,
+        **kwargs,
+    ):
         """Saves an Element into a file.
 
         Parameters
@@ -187,6 +218,7 @@ class Element:
         close_file : bool, default True
             Whether the file has to be closed after write.
         """
+        fid: BinaryIO
         if isinstance(outfile, (str, bytes, Path)):
             fid = open(outfile, "wb")
         else:
@@ -202,15 +234,27 @@ class Element:
 class Link(Element):
     """An abstract class for embedding a link in the HTML."""
 
-    def get_code(self):
+    def __init__(self, url: str, download: bool = False):
+        super().__init__()
+        self.url = url
+        self.code: Optional[bytes] = None
+        if download:
+            self.get_code()
+
+    def get_code(self) -> bytes:
         """Opens the link and returns the response's content."""
         if self.code is None:
             self.code = urlopen(self.url).read()
         return self.code
 
-    def to_dict(self, depth=-1, **kwargs):
+    def to_dict(
+        self,
+        depth: int = -1,
+        ordered: bool = True,
+        **kwargs,
+    ) -> Union[dict, OrderedDict]:
         """Returns a dict representation of the object."""
-        out = super().to_dict(depth=-1, **kwargs)
+        out = super().to_dict(depth=depth, ordered=ordered, **kwargs)
         out["url"] = self.url
         return out
 
@@ -235,13 +279,9 @@ class JavascriptLink(Link):
         "{% endif %}",
     )
 
-    def __init__(self, url, download=False):
-        super().__init__()
+    def __init__(self, url: str, download: bool = False):
+        super().__init__(url=url, download=download)
         self._name = "JavascriptLink"
-        self.url = url
-        self.code = None
-        if download:
-            self.get_code()
 
 
 class CssLink(Link):
@@ -264,13 +304,9 @@ class CssLink(Link):
         "{% endif %}",
     )
 
-    def __init__(self, url, download=False):
-        super().__init__()
+    def __init__(self, url: str, download: bool = False):
+        super().__init__(url=url, download=download)
         self._name = "CssLink"
-        self.url = url
-        self.code = None
-        if download:
-            self.get_code()
 
 
 class Figure(Element):
@@ -314,11 +350,11 @@ class Figure(Element):
 
     def __init__(
         self,
-        width="100%",
-        height=None,
-        ratio="60%",
-        title=None,
-        figsize=None,
+        width: str = "100%",
+        height: Optional[str] = None,
+        ratio: str = "60%",
+        title: Optional[str] = None,
+        figsize: Optional[Tuple[int, int]] = None,
     ):
         super().__init__()
         self._name = "Figure"
@@ -346,7 +382,12 @@ class Figure(Element):
             name="meta_http",
         )
 
-    def to_dict(self, depth=-1, **kwargs):
+    def to_dict(
+        self,
+        depth: int = -1,
+        ordered: bool = True,
+        **kwargs,
+    ) -> Union[dict, OrderedDict]:
         """Returns a dict representation of the object."""
         out = super().to_dict(depth=depth, **kwargs)
         out["header"] = self.header.to_dict(depth=depth - 1, **kwargs)
@@ -354,17 +395,17 @@ class Figure(Element):
         out["script"] = self.script.to_dict(depth=depth - 1, **kwargs)
         return out
 
-    def get_root(self):
+    def get_root(self) -> "Figure":
         """Returns the root of the elements tree."""
         return self
 
-    def render(self, **kwargs):
+    def render(self, **kwargs) -> str:
         """Renders the HTML representation of the element."""
         for name, child in self._children.items():
             child.render(**kwargs)
         return self._template.render(this=self, kwargs=kwargs)
 
-    def _repr_html_(self, **kwargs):
+    def _repr_html_(self, **kwargs) -> str:
         """Displays the Figure in a Jupyter notebook."""
         html = escape(self.render(**kwargs))
         if self.height is None:
@@ -387,7 +428,7 @@ class Figure(Element):
             ).format(html=html, width=self.width, height=self.height)
         return iframe
 
-    def add_subplot(self, x, y, n, margin=0.05):
+    def add_subplot(self, x: int, y: int, n: int, margin: float = 0.05) -> "Div":
         """Creates a div child subplot in a matplotlib.figure.add_subplot style.
 
         Parameters
@@ -398,8 +439,11 @@ class Figure(Element):
             The number of columns in the grid.
         n : int
             The cell number in the grid, counted from 1 to x*y.
+        margin : float, default 0.05
+            Factor to add to the left, top, width and height parameters.
 
-        Example:
+        Example
+        -------
         >>> fig.add_subplot(3, 2, 5)
         # Create a div in the 5th cell of a 3rows x 2columns
         grid(bottom-left corner).
@@ -447,9 +491,15 @@ class Html(Element):
         '<div id="{{this.get_name()}}" '
         'style="width: {{this.width[0]}}{{this.width[1]}}; height: {{this.height[0]}}{{this.height[1]}};">'  # noqa
         "{% if this.script %}{{this.data}}{% else %}{{this.data|e}}{% endif %}</div>",
-    )  # noqa
+    )
 
-    def __init__(self, data, script=False, width="100%", height="100%"):
+    def __init__(
+        self,
+        data: str,
+        script: bool = False,
+        width: TypeParseSize = "100%",
+        height: TypeParseSize = "100%",
+    ):
         super().__init__()
         self._name = "Html"
         self.script = script
@@ -494,11 +544,11 @@ class Div(Figure):
 
     def __init__(
         self,
-        width="100%",
-        height="100%",
-        left="0%",
-        top="0%",
-        position="relative",
+        width: TypeParseSize = "100%",
+        height: TypeParseSize = "100%",
+        left: TypeParseSize = "0%",
+        top: TypeParseSize = "0%",
+        position: str = "relative",
     ):
         super(Figure, self).__init__()
         self._name = "Div"
@@ -522,19 +572,16 @@ class Div(Figure):
         self.html._parent = self
         self.script._parent = self
 
-    def get_root(self):
+    def get_root(self) -> "Div":
         """Returns the root of the elements tree."""
         return self
 
-    def render(self, **kwargs):
+    def render(self, **kwargs) -> str:
         """Renders the HTML representation of the element."""
         figure = self._parent
         assert isinstance(figure, Figure), (
             "You cannot render this Element " "if it is not in a Figure."
         )
-
-        for name, element in self._children.items():
-            element.render(**kwargs)
 
         for name, element in self.header._children.items():
             figure.header.add_child(element, name=name)
@@ -554,14 +601,16 @@ class Div(Figure):
         if script is not None:
             figure.script.add_child(Element(script(self, kwargs)), name=self.get_name())
 
-    def _repr_html_(self, **kwargs):
+        return figure.render()
+
+    def _repr_html_(self, **kwargs) -> str:
         """Displays the Div in a Jupyter notebook."""
         if self._parent is None:
             self.add_to(Figure())
-            out = self._parent._repr_html_(**kwargs)
+            out = self._parent._repr_html_(**kwargs)  # type: ignore
             self._parent = None
         else:
-            out = self._parent._repr_html_(**kwargs)
+            out = self._parent._repr_html_(**kwargs)  # type: ignore
         return out
 
 
@@ -588,7 +637,14 @@ class IFrame(Element):
         width="600px", height="300px".
     """
 
-    def __init__(self, html=None, width="100%", height=None, ratio="60%", figsize=None):
+    def __init__(
+        self,
+        html: Optional[Union[str, Element]] = None,
+        width: str = "100%",
+        height: Optional[str] = None,
+        ratio: str = "60%",
+        figsize: Optional[Tuple[int, int]] = None,
+    ):
         super().__init__()
         self._name = "IFrame"
 
@@ -599,12 +655,12 @@ class IFrame(Element):
             self.width = str(60 * figsize[0]) + "px"
             self.height = str(60 * figsize[1]) + "px"
 
-        if isinstance(html, str) or isinstance(html, bytes):
+        if isinstance(html, str):
             self.add_child(Element(html))
         elif html is not None:
             self.add_child(html)
 
-    def render(self, **kwargs):
+    def render(self, **kwargs) -> str:
         """Renders the HTML representation of the element."""
         html = super().render(**kwargs)
         html = "data:text/html;charset=utf-8;base64," + base64.b64encode(
@@ -658,7 +714,7 @@ class MacroElement(Element):
         super().__init__()
         self._name = "MacroElement"
 
-    def render(self, **kwargs):
+    def render(self, **kwargs) -> str:
         """Renders the HTML representation of the element."""
         figure = self.get_root()
         assert isinstance(figure, Figure), (
@@ -677,5 +733,4 @@ class MacroElement(Element):
         if script is not None:
             figure.script.add_child(Element(script(self, kwargs)), name=self.get_name())
 
-        for name, element in self._children.items():
-            element.render(**kwargs)
+        return figure.render()

--- a/branca/element.py
+++ b/branca/element.py
@@ -184,7 +184,7 @@ class Element:
                 [
                     (name, child.to_dict(depth=depth - 1))
                     for name, child in self._children.items()
-                ]
+                ],
             )
         return out
 

--- a/branca/utilities.py
+++ b/branca/utilities.py
@@ -14,7 +14,7 @@ import re
 import struct
 import typing
 import zlib
-from typing import Any, Callable, Tuple, Union
+from typing import Any, Callable, Tuple, Union, List, Sequence
 
 from jinja2 import Environment, PackageLoader
 
@@ -27,26 +27,29 @@ if typing.TYPE_CHECKING:
     from branca.colormap import ColorMap
 
 
-rootpath = os.path.abspath(os.path.dirname(__file__))
+rootpath: str = os.path.abspath(os.path.dirname(__file__))
 
 
 TypeParseSize = Union[int, float, str, Tuple[float, str]]
 
 
-def get_templates():
+def get_templates() -> Environment:
     """Get Jinja templates."""
     return Environment(loader=PackageLoader("branca", "templates"))
 
 
-def legend_scaler(legend_values, max_labels=10.0):
+def legend_scaler(
+    legend_values: Sequence[float], max_labels: int = 10
+) -> list[Union[float, str]]:
     """
     Downsamples the number of legend values so that there isn't a collision
     of text on the legend colorbar (within reason). The colorbar seems to
     support ~10 entries as a maximum.
 
     """
+    legend_ticks: List[Union[float, str]]
     if len(legend_values) < max_labels:
-        legend_ticks = legend_values
+        legend_ticks = list(legend_values)
     else:
         spacer = int(math.ceil(len(legend_values) / max_labels))
         legend_ticks = []
@@ -56,16 +59,11 @@ def legend_scaler(legend_values, max_labels=10.0):
     return legend_ticks
 
 
-def linear_gradient(hexList, nColors):
+def linear_gradient(hexList: List[str], nColors: int) -> List[str]:
     """
     Given a list of hexcode values, will return a list of length
     nColors where the colors are linearly interpolated between the
     (r, g, b) tuples that are given.
-
-    Examples
-    --------
-    >>> linear_gradient([(0, 0, 0), (255, 0, 0), (255, 255, 0)], 100)
-
     """
 
     def _scale(start, finish, length, i):
@@ -83,7 +81,7 @@ def linear_gradient(hexList, nColors):
             thex = "0" + thex
         return thex
 
-    allColors = []
+    allColors: List[str] = []
     # Separate (R, G, B) pairs.
     for start, end in zip(hexList[:-1], hexList[1:]):
         # Linearly interpolate between pair of hex ###### values and
@@ -96,7 +94,7 @@ def linear_gradient(hexList, nColors):
             allColors.append("".join(["#", r, g, b]))
 
     # Pick only nColors colors from the total list.
-    result = []
+    result: List[str] = []
     for counter in range(nColors):
         fraction = float(counter) / (nColors - 1)
         index = int(fraction * (len(allColors) - 1))

--- a/branca/utilities.py
+++ b/branca/utilities.py
@@ -40,7 +40,7 @@ def get_templates() -> Environment:
 
 def legend_scaler(
     legend_values: Sequence[float], max_labels: int = 10,
-) -> list[Union[float, str]]:
+) -> List[Union[float, str]]:
     """
     Downsamples the number of legend values so that there isn't a collision
     of text on the legend colorbar (within reason). The colorbar seems to

--- a/branca/utilities.py
+++ b/branca/utilities.py
@@ -14,7 +14,7 @@ import re
 import struct
 import typing
 import zlib
-from typing import Any, Callable, Tuple, Union, List, Sequence
+from typing import Any, Callable, List, Sequence, Tuple, Union
 
 from jinja2 import Environment, PackageLoader
 
@@ -39,7 +39,7 @@ def get_templates() -> Environment:
 
 
 def legend_scaler(
-    legend_values: Sequence[float], max_labels: int = 10
+    legend_values: Sequence[float], max_labels: int = 10,
 ) -> list[Union[float, str]]:
     """
     Downsamples the number of legend values so that there isn't a collision

--- a/branca/utilities.py
+++ b/branca/utilities.py
@@ -14,20 +14,23 @@ import re
 import struct
 import typing
 import zlib
-from typing import Any, Callable, Union
+from typing import Any, Callable, Tuple, Union
 
 from jinja2 import Environment, PackageLoader
 
 try:
     import numpy as np
 except ImportError:
-    np = None
+    np = None  # type: ignore
 
 if typing.TYPE_CHECKING:
     from branca.colormap import ColorMap
 
 
 rootpath = os.path.abspath(os.path.dirname(__file__))
+
+
+TypeParseSize = Union[int, float, str, Tuple[float, str]]
 
 
 def get_templates():
@@ -371,7 +374,7 @@ def _camelify(out):
     )  # noqa
 
 
-def _parse_size(value):
+def _parse_size(value: TypeParseSize) -> Tuple[float, str]:
     if isinstance(value, (int, float)):
         return float(value), "px"
     elif isinstance(value, str):

--- a/branca/utilities.py
+++ b/branca/utilities.py
@@ -39,7 +39,8 @@ def get_templates() -> Environment:
 
 
 def legend_scaler(
-    legend_values: Sequence[float], max_labels: int = 10,
+    legend_values: Sequence[float],
+    max_labels: int = 10,
 ) -> List[Union[float, str]]:
     """
     Downsamples the number of legend values so that there isn't a collision

--- a/branca/utilities.py
+++ b/branca/utilities.py
@@ -14,7 +14,7 @@ import re
 import struct
 import typing
 import zlib
-from typing import Any, Callable, List, Sequence, Tuple, Union
+from typing import Any, Callable, List, Sequence, Tuple, Union, Optional
 
 from jinja2 import Environment, PackageLoader
 
@@ -103,7 +103,7 @@ def linear_gradient(hexList: List[str], nColors: int) -> List[str]:
     return result
 
 
-def color_brewer(color_code, n=6):
+def color_brewer(color_code: str, n: int = 6) -> List[str]:
     """
     Generate a colorbrewer color scheme of length 'len', type 'scheme.
     Live examples can be seen at http://colorbrewer2.org/
@@ -200,7 +200,7 @@ def color_brewer(color_code, n=6):
     return color_scheme
 
 
-def image_to_url(image, colormap=None, origin="upper"):
+def image_to_url(image: Any, colormap: Union["ColorMap", Callable, None] = None, origin: str = "upper") -> str:
     """Infers the type of an image argument and transforms it into a URL.
 
     Parameters
@@ -214,7 +214,7 @@ def image_to_url(image, colormap=None, origin="upper"):
     origin : ['upper' | 'lower'], optional, default 'upper'
         Place the [0, 0] index of the array in the upper left or
         lower left corner of the axes.
-    colormap : callable, used only for `mono` image.
+    colormap : ColorMap or callable, used only for `mono` image.
         Function of the form [x -> (r,g,b)] or [x -> (r,g,b,a)]
         for transforming a mono image into RGB.
         It must output iterables of length 3 or 4, with values between
@@ -346,7 +346,7 @@ def write_png(
     )
 
 
-def _camelify(out):
+def _camelify(out: str) -> str:
     return (
         (
             "".join(
@@ -355,12 +355,12 @@ def _camelify(out):
                         "_" + x.lower()
                         if i < len(out) - 1
                         and x.isupper()
-                        and out[i + 1].islower()  # noqa
+                        and out[i + 1].islower()
                         else (
                             x.lower() + "_"
                             if i < len(out) - 1
                             and x.islower()
-                            and out[i + 1].isupper()  # noqa
+                            and out[i + 1].isupper()
                             else x.lower()
                         )
                     )
@@ -370,7 +370,7 @@ def _camelify(out):
         )
         .lstrip("_")
         .replace("__", "_")
-    )  # noqa
+    )
 
 
 def _parse_size(value: TypeParseSize) -> Tuple[float, str]:
@@ -423,7 +423,7 @@ def _locations_tolist(x):
         return x
 
 
-def none_min(x, y):
+def none_min(x: Optional[float], y: Optional[float]) -> Optional[float]:
     if x is None:
         return y
     elif y is None:
@@ -432,7 +432,7 @@ def none_min(x, y):
         return min(x, y)
 
 
-def none_max(x, y):
+def none_max(x: Optional[float], y: Optional[float]) -> Optional[float]:
     if x is None:
         return y
     elif y is None:
@@ -441,7 +441,7 @@ def none_max(x, y):
         return max(x, y)
 
 
-def iter_points(x):
+def iter_points(x: Union[List, Tuple]) -> list:
     """Iterates over a list representing a feature, and returns a list of points,
     whatever the shape of the array (Point, MultiPolyline, etc).
     """

--- a/branca/utilities.py
+++ b/branca/utilities.py
@@ -14,7 +14,7 @@ import re
 import struct
 import typing
 import zlib
-from typing import Any, Callable, List, Sequence, Tuple, Union, Optional
+from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
 
 from jinja2 import Environment, PackageLoader
 
@@ -200,7 +200,11 @@ def color_brewer(color_code: str, n: int = 6) -> List[str]:
     return color_scheme
 
 
-def image_to_url(image: Any, colormap: Union["ColorMap", Callable, None] = None, origin: str = "upper") -> str:
+def image_to_url(
+    image: Any,
+    colormap: Union["ColorMap", Callable, None] = None,
+    origin: str = "upper",
+) -> str:
     """Infers the type of an image argument and transforms it into a URL.
 
     Parameters
@@ -353,14 +357,10 @@ def _camelify(out: str) -> str:
                 [
                     (
                         "_" + x.lower()
-                        if i < len(out) - 1
-                        and x.isupper()
-                        and out[i + 1].islower()
+                        if i < len(out) - 1 and x.isupper() and out[i + 1].islower()
                         else (
                             x.lower() + "_"
-                            if i < len(out) - 1
-                            and x.islower()
-                            and out[i + 1].isupper()
+                            if i < len(out) - 1 and x.islower() and out[i + 1].isupper()
                             else x.lower()
                         )
                     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [build-system]
 requires = ["setuptools>=41.2", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.mypy]
+ignore_missing_imports = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@ flake8-mutable
 flake8-print
 isort
 jupyter
+mypy
 nbsphinx
 nbval
 numpy


### PR DESCRIPTION
- [x] Add type hints to all modules in Branca.
- [x] Make sure Mypy passes.

Contains some (internally) functional changes as well:

- Alter `_parse_hex` to output RGBA floats directly. We only use that function inside of `_parse_color`, which needs RGBA floats as output.
- No longer have `bytes` as accepted type for color strings. That's a remnant from the Python 2 times.
- Merge duplicate code in Link, JavascriptLink and CssLink.

Do separately later:
- make subclasses of `Figure` use the same types for width and height. Also a separate PR I think. Would be easiest to have `_parse_size` just return a single string.
- simplify the `_camelify` function. Is it even needed?
- remove `get_templates`