### PR TITLE
Add jinja2 version constraint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-jinja2
+jinja2>=3


### PR DESCRIPTION
Branca does not work with some older versions of Jinja2, resulting in an `ImportError: cannot import name 'soft_unicode' from 'markupsafe'` (for e.g. `import branca.colormap as colormap`). To address this issue, we have added a version constraint for `Jinja2>=3`.