### PR TITLE
Remove `split_six` utility function

### DIFF
--- a/branca/utilities.py
+++ b/branca/utilities.py
@@ -19,11 +19,6 @@ from typing import Any, Callable, Union
 from jinja2 import Environment, PackageLoader
 
 try:
-    import pandas as pd
-except ImportError:
-    pd = None
-
-try:
     import numpy as np
 except ImportError:
     np = None
@@ -201,39 +196,6 @@ def color_brewer(color_code, n=6):
         else:
             color_scheme = schemes.get(core_color_code, None)[::-1]
     return color_scheme
-
-
-def split_six(series=None):
-    """
-    Given a Pandas Series, get a domain of values from zero to the 90% quantile
-    rounded to the nearest order-of-magnitude integer. For example, 2100 is
-    rounded to 2000, 2790 to 3000.
-
-    Parameters
-    ----------
-    series: Pandas series, default None
-
-    Returns
-    -------
-    list
-
-    """
-    if pd is None:
-        raise ImportError("The Pandas package is required" " for this functionality")
-    if np is None:
-        raise ImportError("The NumPy package is required" " for this functionality")
-
-    def base(x):
-        if x > 0:
-            base = pow(10, math.floor(math.log10(x)))
-            return round(x / base) * base
-        else:
-            return 0
-
-    quants = [0, 50, 75, 85, 90]
-    # Some weirdness in series quantiles a la 0.13.
-    arr = series.values
-    return [base(np.percentile(arr, x)) for x in quants]
 
 
 def image_to_url(image, colormap=None, origin="upper"):


### PR DESCRIPTION
This utility function is not used anywhere in Branca or Folium. It sort of requires Pandas, which is not actually a dependency of Branca. By removing this function, we can also remove that awkward import of Pandas.

- This function was included in the first version, but was not used at that time as well.
- It's also not included in the documentation.
- I couldn't find a reference to it using Github's search function.

I think we're pretty safe to remove it, since I don't expect it will have downstream users. If there are downstream users, they can easily adopt the code themselves, since it's just a few lines.