### PR TITLE
Remove empty plugins folder

### DIFF
--- a/branca/plugins/__init__.py
+++ b/branca/plugins/__init__.py
@@ -1,8 +1,0 @@
-"""
-Branca plugins
---------------
-
-Add different objects/effects in a branca webpage.
-"""
-
-__all__ = []


### PR DESCRIPTION
Branca has a folder called `plugins` with a bare `__init__.py`. Looking at the history, this was created when the repo was set up with the intention of filling it later. That didn't happen, and I don't think there are any plans to add any plugins to Branca. So we can safely clean it up I think.