### PR TITLE
COMPAT: explictly cast numpy floats to native floats

### DIFF
--- a/branca/colormap.py
+++ b/branca/colormap.py
@@ -95,9 +95,13 @@ class ColorMap(MacroElement):
     def render(self, **kwargs):
         """Renders the HTML representation of the element."""
         self.color_domain = [
-            self.vmin + (self.vmax - self.vmin) * k / 499.0 for k in range(500)
+            float(self.vmin + (self.vmax - self.vmin) * k / 499.0) for k in range(500)
         ]
         self.color_range = [self.__call__(x) for x in self.color_domain]
+        
+        # sanitize possible numpy floats to native python floats
+        self.index = [float(i) for i in self.index]
+
         if self.tick_labels is None:
             self.tick_labels = legend_scaler(self.index, self.max_labels)
 

--- a/branca/colormap.py
+++ b/branca/colormap.py
@@ -98,7 +98,7 @@ class ColorMap(MacroElement):
             float(self.vmin + (self.vmax - self.vmin) * k / 499.0) for k in range(500)
         ]
         self.color_range = [self.__call__(x) for x in self.color_domain]
-        
+
         # sanitize possible numpy floats to native python floats
         self.index = [float(i) for i in self.index]
 


### PR DESCRIPTION
Numpy 2.0 returns `np.float64` objects instead of `float`, so when rendered with jinja2, values may look like `[np.float64(3.2),np.float64(4.383333333333334),np.float64(5.566666666666666)]` instead of `[3.2,4.383333333333334,5.566666666666666]`. JavaScript obviously cannot render the former and since there was no error in Python code, the result was just an empty map with errors shows only in the JavaScript console.

I hope these are the only cases where this happens but I have no idea how to test that :D. It fixes https://github.com/python-visualization/folium/issues/1905.