### PR TITLE
Drop Py3.7, add Py3.12

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -11,16 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.11"]
-        # We only run latest Python on macOS and Windows to save resources.
-        include:
-          - os: ubuntu-latest
-            python-version: "3.8"
-          - os: ubuntu-latest
-            python-version: "3.9"
-          - os: ubuntu-latest
-            python-version: "3.10"
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.8", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -53,11 +53,11 @@ setup(
     keywords="data visualization",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "License :: OSI Approved :: MIT License",
         "Development Status :: 5 - Production/Stable",
     ],


### PR DESCRIPTION
We just did the same in Folium in https://github.com/python-visualization/folium/pull/1917.

Also simplify the matrix for the code tests a bit and make it the same as in Folium. This will making upgrading this in the future easier, since we can just copy it.