### PR TITLE
Add `pre-commit` to `requirements-dev.txt`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,7 @@ jupyter
 nbsphinx
 nbval
 numpy
+pre-commit
 pylint
 pytest
 pytest-cov


### PR DESCRIPTION
While setting up `branca`, I found that the `pre-commit` is missing from the requirements file. This PR adds `pre-commit` to the default dev installation.