### PR TITLE
Pre-commit: disable autofix PR's, ignore E203,W503

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+ci:
+    autofix_prs: false
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   hooks:
     - id: flake8
       exclude: docs/source/conf.py
-      args: [--max-line-length=105]
+      args: [--max-line-length=105, "--ignore=E203,W503"]
 
 - repo: https://github.com/pycqa/isort
   rev: 6.0.1


### PR DESCRIPTION
While developing I struggled with the autofix PR's from Pre-commit. It lead to merge conflicts on every push and much frustration. I think it's better to disable it.

I had an other issue also, where Flake8 and Black were disagreeing on a style aspect. Flake8 should ignore two aspects that Black enforces. We may switch to Ruff in the future, but for now just ignore them.

These changes are needed to merge https://github.com/python-visualization/branca/pull/193.

- E203: whitespace before `:` https://www.flake8rules.com/rules/E203.html
- W503: linebreak before operator https://www.flake8rules.com/rules/W503.html