### PR TITLE
Fix ZeroDivisionError in LinearColormap.to_step() with a single step

### DIFF
--- a/branca/colormap.py
+++ b/branca/colormap.py
@@ -445,12 +445,20 @@ class LinearColormap(ColorMap):
         if round_method == "log10":
             index = [_base(x) for x in index]
 
-        colors = [
-            scaled_cm.rgba_floats_tuple(
-                index[i] * (1.0 - i / (n - 1.0)) + index[i + 1] * i / (n - 1.0),
-            )
-            for i in range(n)
-        ]
+        if n == 1:
+            # Steps are normally sampled at points spread evenly across the
+            # colormap, the first at `index[0]` and the last at `index[-1]`.
+            # A single step is the degenerate case of that spread (0 / 0), so
+            # sample the middle instead: the one bin covers the whole range
+            # and gets a color to match.
+            colors = [scaled_cm.rgba_floats_tuple((index[0] + index[1]) / 2.0)]
+        else:
+            colors = [
+                scaled_cm.rgba_floats_tuple(
+                    index[i] * (1.0 - i / (n - 1.0)) + index[i + 1] * i / (n - 1.0),
+                )
+                for i in range(n)
+            ]
 
         caption = self.caption
         text_color = self.text_color

--- a/tests/test_colormap.py
+++ b/tests/test_colormap.py
@@ -89,6 +89,25 @@ def test_linear_to_step():
     lc.to_step(data=some_list, quantiles=[0, 0.3, 0.7, 1], round_method="log10")
 
 
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"n": 1},
+        {"index": [0, 1]},
+        {"data": [0, 0.5, 1], "n": 1},
+        {"data": [0.5, 0.75, 1], "n": 1, "method": "log"},
+        {"data": [0, 0.5, 1], "quantiles": [0, 1]},
+    ],
+)
+def test_linear_to_step_single_step(kwargs):
+    """A one-bin colormap is valid; every path here raised ZeroDivisionError."""
+    linear = cm.LinearColormap(["red", "blue"], vmin=0, vmax=1)
+    step = linear.to_step(**kwargs)
+    assert len(step.colors) == 1
+    # The single bin spans the whole range, so it takes the middle color.
+    assert step.colors[0] == linear.rgba_floats_tuple(0.5)
+
+
 def test_step_to_linear():
     step = cm.StepColormap(
         ["green", "yellow", "red"],


### PR DESCRIPTION
Fixes #222.

`to_step()` computes each step's color by sampling the colormap at points spread evenly across the range — the first step at `index[0]`, the last at `index[-1]`. The interpolation weight is `i / (n - 1.0)`, which is `0 / 0` when there is only one step, so the call raises `ZeroDivisionError`.

The report is about `to_step(n=1)`, but `n` is recomputed as `len(index) - 1` further up, so every path that produces a two-element index hits this. All of these raise on `main`:

```python
cm = LinearColormap(["red", "blue"], vmin=0, vmax=1)

cm.to_step(n=1)
cm.to_step(index=[0, 1])
cm.to_step(data=[0, 0.5, 1], n=1)
cm.to_step(data=[0.5, 0.75, 1], n=1, method="log")
cm.to_step(data=[0, 0.5, 1], quantiles=[0, 1])
```

Of the three options raised in the issue, this takes the first — returning a one-bin `StepColormap`. A single bin spans the whole range, so it is sampled at the middle of the colormap rather than at either endpoint, which keeps it unbiased between the two ends and matches the middle element for odd `n` (`to_step(n=3)` already samples `index[0]`, the midpoint, and `index[-1]`).

The `n >= 2` branch is left byte-for-byte identical rather than refactored into a shared expression. `index[i + 1] * i / (n - 1.0)` parses as `(index[i + 1] * i) / (n - 1.0)`, so hoisting the weight into a variable changes the floating-point result for many `n` — verified against the original expression for `n = 2..199`, where the hoisted form differs on 29 of them and this form differs on none.

Happy to switch to an explicit `ValueError` for `n < 2` instead if you'd prefer that reading — the crash seemed worth fixing either way.

### Testing

- New parametrized test covers all five entry paths above and asserts the single bin takes the middle color.
- `tests/test_colormap.py` passes in full (20 tests).
- `test_iframe.py` (selenium) and two `test_utilities.py` png tests (numpy) fail identically before and after this change — missing optional deps in my environment, unrelated to this PR.
- `black`, `flake8 --max-line-length=105 --ignore=E203,W503`, and `isort --profile black` are all clean.